### PR TITLE
style: correct spelling and enforce linter check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,9 +85,12 @@ linters:
     - stylecheck
     - usestdlibvars
     - wrapcheck
+    - misspell
 
 linters-settings:
   staticcheck:
     go: "1.18"
     # https://staticcheck.io/docs/options#checks
     checks: ["all", "-ST1000", "-SA1019"]
+  misspell:
+    locale: US

--- a/cmd/wfxctl/errutil/util.go
+++ b/cmd/wfxctl/errutil/util.go
@@ -59,7 +59,7 @@ func extractErrors(val any) []*model.Error {
 // Note: This function will terminate the program if the error is not nil. Use with caution.
 func Must[T any](value T, err error) T {
 	if err != nil {
-		log.Fatal().Err(err).Msg("A fatal error has occured")
+		log.Fatal().Err(err).Msg("A fatal error has occurred")
 	}
 	return value
 }


### PR DESCRIPTION
### Description

Correct the spelling of "occurred" from its incorrect form "occured". Integrate a spell-check linter into the build process to automatically identify and prevent spelling mistakes in the future.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
