### PR TITLE
 fix: send HTTP code 404 if file server disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Send HTTP status code 404 when attempting to access the file server while it is disabled
+
 ### Changed
 
 ### Removed

--- a/middleware/fileserver/fileserver.go
+++ b/middleware/fileserver/fileserver.go
@@ -46,8 +46,8 @@ func NewFileServerMiddleware(k *config.ThreadSafeKoanf, next http.Handler) (http
 			})
 			if rootDir != "" {
 				http.StripPrefix("/download", http.FileServer(http.Dir(rootDir))).ServeHTTP(w, r)
+				return
 			}
-			return
 		}
 		next.ServeHTTP(w, r)
 	}), nil

--- a/middleware/fileserver/fileserver_test.go
+++ b/middleware/fileserver/fileserver_test.go
@@ -100,3 +100,18 @@ func TestFileServerMiddleware_DirIsFile(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "not a directory")
 }
+
+func TestFileServerMiddleware_404(t *testing.T) {
+	k := config.New()
+	handler, err := NewFileServerMiddleware(k, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	require.Nil(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/download", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+}


### PR DESCRIPTION
### Description

Send HTTP status code 404 when attempting to access the file server while it is disabled.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
