### PR TITLE
Configure TLS for Southbound API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,69 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
 
+  cli-tests:
+    name: CLI Tests
+    runs-on: ubuntu-latest
+    container: debian:bookworm-slim
+    services:
+      mysql:
+        image: mysql:8-debian
+        env:
+          # see https://hub.docker.com/_/mysql
+          MYSQL_DATABASE: wfx
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: wfx
+          MYSQL_PASSWORD: secret
+          MYSQL_HOST: mysql
+        # Set health checks to wait until mysql has started
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 20
+      postgres:
+        image: postgres:15
+        env:
+          # see https://hub.docker.com/_/postgres
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: wfx
+          POSTGRES_USER: wfx
+          POSTGRES_PASSWORD: secret
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Install packages
+        run: apt-get update -q && apt-get install -y --no-install-recommends bats make gcc libc6-dev golang git curl openssl jq systemd ca-certificates procps
+      - uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - name: Disable git security features
+        run: git config --global safe.directory '*'
+      - name: build wfx
+        run: make
+      - name: install wfx
+        run: make install
+      - name: run tests
+        env:
+          PGHOST: postgres
+          PGPORT: 5432
+          PGUSER: wfx
+          PGPASSWORD: secret
+          PGDATABASE: wfx
+          MYSQL_DATABASE: wfx
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: wfx
+          MYSQL_PASSWORD: secret
+          MYSQL_HOST: mysql
+        working-directory: test
+        run: bats .
+
   lint:
     runs-on: ubuntu-latest
     name: Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
     - dupword
     - errname
     - errorlint
+    - exhaustive
     - exportloopref
     - gocheckcompilerdirectives
     - goconst
@@ -94,3 +95,5 @@ linters-settings:
     checks: ["all", "-ST1000", "-SA1019"]
   misspell:
     locale: US
+  exhaustive:
+    default-signifies-exhaustive: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Send HTTP status code 404 when attempting to access the file server while it is disabled
+- Configure TLS for Southbound API (if requested via CLI)
 
 ### Changed
 

--- a/cmd/wfx/cmd/root/cmd.go
+++ b/cmd/wfx/cmd/root/cmd.go
@@ -171,16 +171,20 @@ Examples of tasks are installation of firmware or other types of commands issued
 
 		signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 
+		var schemes []string
+		k.Read(func(k *koanf.Koanf) {
+			schemes = k.Strings(schemeFlag)
+		})
 		allServers := make([]myServer, 0, 6)
 		{
-			servers, err := createNorthboundServers(storage)
+			servers, err := createNorthboundServers(schemes, storage)
 			if err != nil {
 				return fault.Wrap(err)
 			}
 			allServers = append(allServers, servers...)
 		}
 		{
-			servers, err := createSouthboundServers(storage)
+			servers, err := createSouthboundServers(schemes, storage)
 			if err != nil {
 				return fault.Wrap(err)
 			}

--- a/cmd/wfx/cmd/root/northbound.go
+++ b/cmd/wfx/cmd/root/northbound.go
@@ -9,14 +9,9 @@ package root
  */
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fmsg"
-	"github.com/go-openapi/runtime/flagext"
 	"github.com/knadh/koanf/v2"
-	"github.com/rs/zerolog/log"
 	"github.com/siemens/wfx/api"
 	"github.com/siemens/wfx/generated/northbound/restapi"
 	"github.com/siemens/wfx/internal/server"
@@ -24,95 +19,31 @@ import (
 	"github.com/siemens/wfx/persistence"
 )
 
-func createNorthboundServers(storage persistence.Storage) ([]myServer, error) {
-	result := make([]myServer, 0, 3)
-
-	var schemes []string
+func createNorthboundServers(schemes []string, storage persistence.Storage) ([]myServer, error) {
+	var settings server.HTTPSettings
 	k.Read(func(k *koanf.Koanf) {
-		schemes = k.Strings(schemeFlag)
+		settings.Host = k.String(mgmtHostFlag)
+		settings.TLSHost = k.String(mgmtTLSHostFlag)
+		settings.Port = k.Int(mgmtPortFlag)
+		settings.TLSPort = k.Int(mgmtTLSPortFlag)
+		settings.UDSPath = k.String(mgmtUnixSocketFlag)
 	})
-
-	for _, scheme := range schemes {
-		kind, err := parseServerKind(scheme)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		srv, err := createNorthboundServer(storage, *kind)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		result = append(result, *srv)
-	}
-	return result, nil
-}
-
-func createNorthboundServer(storage persistence.Storage, kind serverKind) (*myServer, error) {
-	log.Debug().Str("kind", kind.String()).Msg("Creating northbound server")
-
+	swaggerJSON, _ := restapi.SwaggerJSON.MarshalJSON()
 	api, err := api.NewNorthboundAPI(storage)
 	if err != nil {
 		return nil, fault.Wrap(err, fmsg.With("Failed to create northbound API"))
 	}
-
-	swaggerJSON, _ := restapi.SwaggerJSON.MarshalJSON()
 	cfg := middleware.Config{
 		Config:      k,
 		Storage:     storage,
 		BasePath:    api.Context().BasePath(),
 		SwaggerJSON: swaggerJSON,
 	}
-
 	// add our global middlewares
 	handler, err := middleware.SetupGlobalMiddleware(cfg, restapi.ConfigureAPI(api))
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-
-	var settings server.HTTPSettings
-	var mgmtHost, mgmtTLSHost string
-	var mgmtPort, mgmtTLSPort int
-	k.Read(func(k *koanf.Koanf) {
-		settings.MaxHeaderSize = flagext.ByteSize(k.Int(maxHeaderSizeFlag))
-		settings.KeepAlive = k.Duration(keepAliveFlag)
-		settings.ReadTimeout = k.Duration(readTimeoutFlag)
-		settings.WriteTimeout = k.Duration(writeTimoutFlag)
-		settings.CleanupTimeout = k.Duration(cleanupTimeoutFlag)
-
-		mgmtHost = k.String(mgmtHostFlag)
-		mgmtTLSHost = k.String(mgmtTLSHostFlag)
-		mgmtPort = k.Int(mgmtPortFlag)
-		mgmtTLSPort = k.Int(mgmtTLSPortFlag)
-	})
-
-	switch kind {
-	case kindHTTP:
-		log.Debug().Msg("Creating http server")
-		srv := server.NewHTTPServer(&settings, handler)
-		srv.Addr = fmt.Sprintf("%s:%d", mgmtHost, mgmtPort)
-		return &myServer{Srv: srv, Kind: kind}, nil
-	case kindHTTPS:
-		log.Debug().Msg("Creating https server")
-		srv := server.NewHTTPServer(&settings, handler)
-		srv.Addr = fmt.Sprintf("%s:%d", mgmtTLSHost, mgmtTLSPort)
-		var tlsSettings server.TLSSettings
-		k.Read(func(k *koanf.Koanf) {
-			tlsSettings.TLSCertificate = k.String(tlsCertificateFlag)
-			tlsSettings.TLSCertificateKey = k.String(tlsKeyFlag)
-			tlsSettings.TLSCACertificate = k.String(tlsCaFlag)
-		})
-		err := server.ConfigureTLS(srv, &tlsSettings)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		return &myServer{Srv: srv, Kind: kind}, nil
-	case kindUnix:
-		log.Debug().Msg("Creating unix-domain socket server")
-		srv := server.NewHTTPServer(&settings, handler)
-		k.Read(func(k *koanf.Koanf) {
-			srv.Addr = k.String(mgmtUnixSocketFlag)
-		})
-		return &myServer{Srv: srv, Kind: kind}, nil
-	default:
-		return nil, errors.New("unsupported server kind")
-	}
+	servers, err := createServers(schemes, handler, settings)
+	return servers, fault.Wrap(err)
 }

--- a/cmd/wfx/cmd/root/server_test.go
+++ b/cmd/wfx/cmd/root/server_test.go
@@ -9,13 +9,87 @@ package root
  */
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path"
 	"testing"
+	"time"
 
+	"github.com/knadh/koanf/v2"
+	"github.com/siemens/wfx/internal/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerKind(t *testing.T) {
 	assert.Equal(t, "http", kindHTTP.String())
 	assert.Equal(t, "https", kindHTTPS.String())
 	assert.Equal(t, "unix", kindUnix.String())
+}
+
+func TestCreateServers_InvalidKind(t *testing.T) {
+	_, err := createServers([]string{"foo"}, nil, server.HTTPSettings{})
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "unknown scheme: foo")
+}
+
+func TestCreateServers_TLS(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "My CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1), // Valid for 1 day
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	dir, err := os.MkdirTemp(os.TempDir(), "wfx-tlsca")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	caCrtFile := path.Join(dir, "ca.crt")
+	caKeyFile := path.Join(dir, "ca.key")
+	{
+		certOut, err := os.Create(caCrtFile)
+		require.NoError(t, err)
+		defer certOut.Close()
+
+		err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+		require.NoError(t, err)
+
+		keyOut, err := os.OpenFile(caKeyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		require.NoError(t, err)
+		defer keyOut.Close()
+
+		err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+		require.NoError(t, err)
+	}
+
+	k.Write(func(k *koanf.Koanf) {
+		_ = k.Set(tlsCertificateFlag, caCrtFile)
+		_ = k.Set(tlsKeyFlag, caKeyFile)
+		_ = k.Set(tlsCaFlag, caCrtFile)
+	})
+
+	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	})
+
+	servers, err := createServers([]string{kindHTTPS.String()}, handler, server.HTTPSettings{})
+	require.Nil(t, err)
+	require.Len(t, servers, 1)
+	assert.Equal(t, kindHTTPS, servers[0].Kind)
+	assert.NotEmpty(t, servers[0].Srv.TLSConfig.Certificates)
 }

--- a/cmd/wfx/cmd/root/southbound.go
+++ b/cmd/wfx/cmd/root/southbound.go
@@ -9,14 +9,9 @@ package root
  */
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/fmsg"
-	"github.com/go-openapi/runtime/flagext"
 	"github.com/knadh/koanf/v2"
-	"github.com/rs/zerolog/log"
 	"github.com/siemens/wfx/api"
 	"github.com/siemens/wfx/generated/southbound/restapi"
 	"github.com/siemens/wfx/internal/server"
@@ -24,95 +19,32 @@ import (
 	"github.com/siemens/wfx/persistence"
 )
 
-func createSouthboundServers(storage persistence.Storage) ([]myServer, error) {
-	result := make([]myServer, 0, 3)
-
-	var schemes []string
+func createSouthboundServers(schemes []string, storage persistence.Storage) ([]myServer, error) {
+	var settings server.HTTPSettings
 	k.Read(func(k *koanf.Koanf) {
-		schemes = k.Strings(schemeFlag)
+		settings.Host = k.String(clientHostFlag)
+		settings.TLSHost = k.String(clientTLSHostFlag)
+		settings.Port = k.Int(clientPortFlag)
+		settings.TLSPort = k.Int(clientTLSPortFlag)
+		settings.UDSPath = k.String(clientUnixSocket)
 	})
-	for _, scheme := range schemes {
-		kind, err := parseServerKind(scheme)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		srv, err := createSouthboundServer(storage, *kind)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		result = append(result, *srv)
-	}
-
-	return result, nil
-}
-
-func createSouthboundServer(storage persistence.Storage, kind serverKind) (*myServer, error) {
-	log.Debug().Str("kind", kind.String()).Msg("Creating southbound server")
-
+	swaggerJSON, _ := restapi.SwaggerJSON.MarshalJSON()
 	api, err := api.NewSouthboundAPI(storage)
 	if err != nil {
 		return nil, fault.Wrap(err, fmsg.With("Failed to create southbound API"))
 	}
-
-	swaggerJSON, _ := restapi.SwaggerJSON.MarshalJSON()
 	cfg := middleware.Config{
 		Config:      k,
 		Storage:     storage,
 		BasePath:    api.Context().BasePath(),
 		SwaggerJSON: swaggerJSON,
 	}
-
 	// add our global middlewares
 	handler, err := middleware.SetupGlobalMiddleware(cfg, restapi.ConfigureAPI(api))
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
 
-	var settings server.HTTPSettings
-	var clientHost, clientTLSHost string
-	var clientPort, clientTLSPort int
-	k.Read(func(k *koanf.Koanf) {
-		settings.MaxHeaderSize = flagext.ByteSize(k.Int(maxHeaderSizeFlag))
-		settings.KeepAlive = k.Duration(keepAliveFlag)
-		settings.ReadTimeout = k.Duration(readTimeoutFlag)
-		settings.WriteTimeout = k.Duration(writeTimoutFlag)
-		settings.CleanupTimeout = k.Duration(cleanupTimeoutFlag)
-
-		clientHost = k.String(clientHostFlag)
-		clientTLSHost = k.String(clientTLSHostFlag)
-		clientPort = k.Int(clientPortFlag)
-		clientTLSPort = k.Int(clientTLSPortFlag)
-	})
-
-	switch kind {
-	case kindHTTP:
-		log.Debug().Msg("Creating http server")
-		srv := server.NewHTTPServer(&settings, handler)
-		srv.Addr = fmt.Sprintf("%s:%d", clientHost, clientPort)
-		return &myServer{Srv: srv, Kind: kind}, nil
-	case kindHTTPS:
-		log.Debug().Msg("Creating https server")
-		srv := server.NewHTTPServer(&settings, handler)
-		srv.Addr = fmt.Sprintf("%s:%d", clientTLSHost, clientTLSPort)
-		var tlsSettings server.TLSSettings
-		k.Read(func(k *koanf.Koanf) {
-			tlsSettings.TLSCertificate = k.String(tlsCertificateFlag)
-			tlsSettings.TLSCertificateKey = k.String(tlsKeyFlag)
-			tlsSettings.TLSCACertificate = k.String(tlsCaFlag)
-		})
-		err := server.ConfigureTLS(srv, &tlsSettings)
-		if err != nil {
-			return nil, fault.Wrap(err)
-		}
-		return &myServer{Srv: srv, Kind: kind}, nil
-	case kindUnix:
-		log.Debug().Msg("Creating unix-domain socket server")
-		srv := server.NewHTTPServer(&settings, handler)
-		k.Read(func(k *koanf.Koanf) {
-			srv.Addr = k.String(clientUnixSocket)
-		})
-		return &myServer{Srv: srv, Kind: kind}, nil
-	default:
-		return nil, errors.New("unsupported server kind")
-	}
+	servers, err := createServers(schemes, handler, settings)
+	return servers, fault.Wrap(err)
 }

--- a/cmd/wfx/cmd/root/southbound.go
+++ b/cmd/wfx/cmd/root/southbound.go
@@ -100,6 +100,7 @@ func createSouthboundServer(storage persistence.Storage, kind serverKind) (*mySe
 			tlsSettings.TLSCertificateKey = k.String(tlsKeyFlag)
 			tlsSettings.TLSCACertificate = k.String(tlsCaFlag)
 		})
+		err := server.ConfigureTLS(srv, &tlsSettings)
 		if err != nil {
 			return nil, fault.Wrap(err)
 		}

--- a/cmd/wfx/cmd/root/systemd.go
+++ b/cmd/wfx/cmd/root/systemd.go
@@ -32,11 +32,12 @@ func adoptSystemdSockets(listeners []net.Listener, storage persistence.Storage, 
 		Msg("Received socket fds from systemd")
 
 	go func() {
-		srv, err := createSouthboundServer(storage, kindHTTP)
+		servers, err := createSouthboundServers([]string{kindHTTP.String()}, storage)
 		if err != nil {
 			errChan <- err
 			return
 		}
+		srv := servers[0]
 
 		log.Info().Msg("Starting southbound UDS listener (activated by systemd)")
 		l := listeners[0]
@@ -48,11 +49,12 @@ func adoptSystemdSockets(listeners []net.Listener, storage persistence.Storage, 
 	}()
 
 	go func() {
-		srv, err := createNorthboundServer(storage, kindHTTP)
+		servers, err := createNorthboundServers([]string{kindHTTP.String()}, storage)
 		if err != nil {
 			errChan <- err
 			return
 		}
+		srv := servers[0]
 
 		log.Info().Msg("Starting northbound UDS listener (activated by systemd)")
 		l := listeners[1]

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -16,6 +16,11 @@ import (
 )
 
 type HTTPSettings struct {
+	Host           string
+	Port           int
+	TLSHost        string
+	TLSPort        int
+	UDSPath        string
 	MaxHeaderSize  flagext.ByteSize
 	KeepAlive      time.Duration
 	ReadTimeout    time.Duration

--- a/test/02-configuration.bats
+++ b/test/02-configuration.bats
@@ -33,18 +33,18 @@ teardown() {
 
 @test "PostgreSQL storage using cli args" {
     wfx --storage postgres \
-        --storage-opt "host=localhost port=5432 user=wfx password=secret database=wfx" &
+        --storage-opt "host=${PGHOST:-localhost} port=${PGPORT:-5432} user=${PGUSER:-wfx} password=${PGPASSWORD:-secret} database=${PGDATABASE:-wfx}" &
     local count
     count=$(wait_wfx_running)
     assert_equal "$count" 2
 }
 
 @test "PostgreSQL storage using env variables" {
-    env PGHOST=localhost \
-        PGPORT=5432 \
-        PGUSER=wfx \
-        PGPASSWORD=secret \
-        PGDATABASE=wfx \
+    env PGHOST=${PGHOST:-localhost} \
+        PGPORT=${PGPORT:-5432} \
+        PGUSER=${PGUSER:-wfx} \
+        PGPASSWORD=${PGPASSWORD:-secret} \
+        PGDATABASE=${PGDATABASE:-wfx} \
         wfx --storage postgres &
     local count
     count=$(wait_wfx_running)
@@ -53,7 +53,7 @@ teardown() {
 
 @test "MySQL storage" {
     wfx --storage mysql \
-        --storage-opt "root:root@tcp(localhost:3306)/wfx" &
+        --storage-opt "${MYSQL_USER:-root}:${MYSQL_PASSWORD:-root}@tcp(${MYSQL_HOST:-localhost}:${MYSQL_PORT:-3306})/${MYSQL_DATABASE:-wfx}" &
     local count
     count=$(wait_wfx_running)
     assert_equal "$count" 2

--- a/test/04-operations.bats
+++ b/test/04-operations.bats
@@ -59,3 +59,22 @@ teardown_file() {
     count=$(wait_wfx_running 4)
     assert_equal "$count" 4
 }
+
+@test "Socket-based activation" {
+  cd "$BATS_TEST_TMPDIR"
+  systemd-socket-activate \
+    --listen "$BATS_TEST_TMPDIR/wfx-client.sock" \
+    --listen "$BATS_TEST_TMPDIR/wfx-mgmt.sock" \
+    wfx --scheme unix &
+  local i=0
+  while [[ $i -lt 30 ]]; do
+    RC=0
+    wfxctl --client-unix-socket "$BATS_TEST_TMPDIR/wfx-client.sock" version || RC=$?
+    if [[ $RC -eq 0 ]]; then
+      return 0
+    fi
+    sleep 1
+    i=$((i+1))
+  done
+  return 1
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: 2023 Siemens AG
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Author: Michael Adler <michael.adler@siemens.com>
-
-.PHONY: test
-test:
-	@bats --formatter tap .


### PR DESCRIPTION
### Description

It was observed that the TLS configuration was omitted for the Southbound API. Although there is a test case to validate this configuration, it was previously executed manually, which led to it being inadvertently neglected on a regular basis. To address this, the present merge request not only includes the requisite changes for configuring TLS for the Southbound API but also automates the execution of the CLI tests within the Continuous Integration (CI) pipeline.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [X] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
