### PR TITLE
fix(demo): run kanban demo in an infinite loop

### DIFF
--- a/share/demo/kanban/02-create-workflow.sh
+++ b/share/demo/kanban/02-create-workflow.sh
@@ -52,5 +52,3 @@ VALIDATE ─────┤
     ▼         ▼
   DONE    DISCARDED
 EOF
-
-touch 02-create-workflow.sh.done

--- a/share/demo/kanban/03-producer.sh
+++ b/share/demo/kanban/03-producer.sh
@@ -6,15 +6,20 @@
 # Author: Michael Adler <michael.adler@siemens.com>
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-rm -f 02-create-workflow.sh.done
 
 # hide the evidence
 clear
 
-echo "# waiting for workflow..."
-while [[ ! -e 02-create-workflow.sh.done ]]; do
-    sleep 0.5
+echo "# waiting for kanban workflow..."
+while true; do
+    RC=0
+    wfxctl workflow get --name=wfx.workflow.kanban 1>/dev/null 2>&1 || RC=$?
+    if [[ $RC -eq 0 ]]; then
+        break
+    fi
+    sleep 3
 done
+echo "# found kanban workflow"
 
 ########################
 # include the magic
@@ -27,11 +32,13 @@ PROMPT_TIMEOUT=2
 
 CLIENTS=("$@")
 TASKID=1
-for client in "${CLIENTS[@]}"; do
-    clear
-    p "# create a task for developer $client"
-    p "echo '{ \"title\": \"Task $TASKID\" }' | wfxctl job create --workflow wfx.workflow.kanban --client-id $client --filter 'del(.workflow)'"
-    echo "{ \"title\": \"Task $TASKID\" }" | wfxctl job create --workflow wfx.workflow.kanban --client-id "$client" --filter 'del(.workflow)' -
-    sleep 3
-    TASKID=$((TASKID + 1))
+while true; do
+    for client in "${CLIENTS[@]}"; do
+        clear
+        p "# create a task for developer $client"
+        p "echo '{ \"title\": \"Task $TASKID\" }' | wfxctl job create --workflow wfx.workflow.kanban --client-id $client --filter 'del(.workflow)'"
+        echo "{ \"title\": \"Task $TASKID\" }" | wfxctl job create --workflow wfx.workflow.kanban --client-id "$client" --filter 'del(.workflow)' -
+        sleep 3
+        TASKID=$((TASKID + 1))
+    done
 done


### PR DESCRIPTION
### Description

This commit addresses an issue where the producer in the Kanban demo would halt after generating a certain number of jobs. Earlier, even if the producer was restarted, it wouldn’t resume the job generation due to the presence of a '.done' marker file.
The marker file mechanism was therefore replaced with a simple polling approach. Now restarting the producer works and will result in new jobs being generated.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
