### PR TITLE
test: ensure wfx shutdown after each test run

### DIFF
--- a/test/04-operations.bats
+++ b/test/04-operations.bats
@@ -16,8 +16,11 @@ setup_file() {
 }
 
 teardown_file() {
-  pkill wfx
   rm -f "$PUBLIC_KEY" "$PRIVATE_KEY"
+}
+
+teardown() {
+  pkill wfx
 }
 
 @test "TLS only" {


### PR DESCRIPTION
### Description

Updated the teardown process to halt wfx after every test. This addresses issues where subsequent tests couldn't bind to certain ports due to lingering wfx instances.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
