### PR TITLE
Fix deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["stable", "1.18"]
+        go: ["stable", "1.19"]
     name: Build (Go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,7 +90,7 @@ linters:
 
 linters-settings:
   staticcheck:
-    go: "1.18"
+    go: "1.19"
     # https://staticcheck.io/docs/options#checks
     checks: ["all", "-ST1000", "-SA1019"]
   misspell:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,7 +106,6 @@ archives:
     name_template: >-
       {{.Binary}}-{{.Version}}-{{.Os}}-{{- if eq .Arch "amd64" }}x86_64{{ else }}{{.Arch}}{{ end }}{{ if .Arm }}v{{.Arm }}{{ end }}
     format: tar.xz
-    rlcp: true
     files:
       - LICENSE
       - README.md
@@ -119,7 +118,6 @@ archives:
     name_template: >-
       {{.Binary}}-{{.Version}}-{{.Os}}-{{- if eq .Arch "amd64" }}x86_64{{ else }}{{.Arch}}{{ end }}{{ if .Arm }}v{{.Arm }}{{ end }}
     format: tar.xz
-    rlcp: true
     files:
       - LICENSE
 
@@ -129,7 +127,6 @@ archives:
     name_template: >-
       {{.Binary}}-{{.Version}}-{{.Os}}-{{- if eq .Arch "amd64" }}x86_64{{ else }}{{.Arch}}{{ end }}{{ if .Arm }}v{{.Arm }}{{ end }}
     format: tar.xz
-    rlcp: true
     files:
       - LICENSE
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ necessary.
 
 ## Building wfx
 
-A recent [Go compiler](https://go.dev/) >= 1.18 as well as [GNU make](https://www.gnu.org/software/make/) wrapping the `go build` commands is required to build wfx and its associated tools.
+A recent [Go compiler](https://go.dev/) >= 1.19 as well as [GNU make](https://www.gnu.org/software/make/) wrapping the `go build` commands is required to build wfx and its associated tools.
 
 wfx requires a persistent storage to save workflows and jobs.
 Go [Build Tags](https://pkg.go.dev/go/build) are used to select compiled-in support for different persistent storage options.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/siemens/wfx
 
-go 1.18
+go 1.19
 
 require (
 	entgo.io/ent v0.12.3

--- a/internal/persistence/entgo/sqlite_test.go
+++ b/internal/persistence/entgo/sqlite_test.go
@@ -13,7 +13,6 @@ package entgo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -58,7 +57,7 @@ func setupSQLite(t *testing.T) SQLite {
 	l := log.With().Str("reqID", reqID).Logger()
 	ctx := context.WithValue(context.Background(), logging.KeyRequestLogger, l)
 
-	dir, err := ioutil.TempDir("", "wfx.db.*")
+	dir, err := os.MkdirTemp("", "wfx.db.*")
 	require.NoError(t, err)
 	f, err := os.Create(path.Join(dir, "wfx.db"))
 	require.NoError(t, err)

--- a/middleware/fileserver/fileserver_test.go
+++ b/middleware/fileserver/fileserver_test.go
@@ -10,7 +10,7 @@ package fileserver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -45,7 +45,7 @@ func TestFileServerMiddleware_Fallback(t *testing.T) {
 
 	res := w.Result()
 	defer res.Body.Close()
-	b, _ := ioutil.ReadAll(res.Body)
+	b, _ := io.ReadAll(res.Body)
 	assert.Equal(t, "Hello, client\n", string(b))
 }
 
@@ -73,7 +73,7 @@ func TestFileServerMiddleware_Download(t *testing.T) {
 
 	res := w.Result()
 	defer res.Body.Close()
-	b, _ := ioutil.ReadAll(res.Body)
+	b, _ := io.ReadAll(res.Body)
 	assert.Equal(t, "world", string(b))
 }
 

--- a/middleware/logging/writer_test.go
+++ b/middleware/logging/writer_test.go
@@ -9,7 +9,7 @@ package logging
  */
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +32,7 @@ func TestWriter(t *testing.T) {
 	result := recorder.Result()
 	assert.Equal(t, http.StatusOK, result.StatusCode)
 
-	body, err := ioutil.ReadAll(result.Body)
+	body, err := io.ReadAll(result.Body)
 	require.NoError(t, err)
 	defer result.Body.Close()
 


### PR DESCRIPTION
### Description

- ioutil is deprecated in Go 1.19, see https://pkg.go.dev/io/ioutil@go1.19
- require at least Go 1.19 (1.18 is end-of-life)
- goreleaser rlcp is now the default and can't be changed

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
