### PR TITLE
ci: restrict swagger code purging to own files

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,8 +86,10 @@ _generate-swagger:
     set -euxo pipefail
     cd "{{ THISDIR }}/generated"
 
-    # clean up
-    find . -not -name configure_workflow_executor.go -and -not -path "./ent/*" -type f -delete
+    # remove existing code
+    for dir in client model northbound southbound; do
+        find $dir -not -name configure_workflow_executor.go -type f -delete
+    done
 
     # generate spec (inline anchors)
     just -d . --justfile ../spec/justfile generate wfx.swagger.yml


### PR DESCRIPTION
### Description

Currently everything except for the `ent` directory is removed. This does not scale when adding more generated code. Instead, the swagger task should only purge its own files (before recreating them).

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
