### PR TITLE
fix: ensure immediate shutdown on signals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,3 +97,6 @@ linters-settings:
     locale: US
   exhaustive:
     default-signifies-exhaustive: true
+  wrapcheck:
+    ignorePackageGlobs:
+      - github.com/siemens/wfx/internal/errutil

--- a/api/northbound.go
+++ b/api/northbound.go
@@ -11,7 +11,6 @@ package api
 import (
 	"net/http"
 
-	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/ftag"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
@@ -28,11 +27,10 @@ import (
 	"github.com/siemens/wfx/persistence"
 )
 
-func NewNorthboundAPI(storage persistence.Storage) (*operations.WorkflowExecutorAPI, error) {
-	swaggerSpec, err := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
-	if err != nil {
-		return nil, fault.Wrap(err)
-	}
+func NewNorthboundAPI(storage persistence.Storage) *operations.WorkflowExecutorAPI {
+	// NOTE: loads.Embedded only fails when given invalid JSON input; in our
+	// context, the JSON is always valid, so we may safely ignore the error.
+	swaggerSpec, _ := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	serverAPI := operations.NewWorkflowExecutorAPI(swaggerSpec)
 
 	serverAPI.NorthboundGetJobsHandler = northbound.GetJobsHandlerFunc(
@@ -263,5 +261,5 @@ func NewNorthboundAPI(storage persistence.Storage) (*operations.WorkflowExecutor
 			return northbound.NewDeleteJobsIDTagsOK().WithPayload(tags)
 		})
 
-	return serverAPI, nil
+	return serverAPI
 }

--- a/api/northbound_test.go
+++ b/api/northbound_test.go
@@ -97,7 +97,7 @@ func (st *faultyStorage) QueryWorkflows(context.Context, persistence.PaginationP
 }
 
 func TestNorthboundGetJobsIDStatusHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewGetJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -112,7 +112,7 @@ func TestNorthboundGetJobsIDStatusHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundPutJobsIDStatusHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewPutJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -127,7 +127,7 @@ func TestNorthboundPutJobsIDStatusHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundGetJobsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetJobsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -141,7 +141,7 @@ func TestNorthboundGetJobsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewGetJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -155,7 +155,7 @@ func TestNorthboundGetJobsIDHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -171,7 +171,7 @@ func TestNorthboundGetJobsIDHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDStatusHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -185,7 +185,7 @@ func TestNorthboundGetJobsIDStatusHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundPutJobsIDStatusHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPutJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -199,7 +199,7 @@ func TestNorthboundPutJobsIDStatusHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDDefinitionHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewGetJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -213,7 +213,7 @@ func TestNorthboundGetJobsIDDefinitionHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDDefinitionHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -227,7 +227,7 @@ func TestNorthboundGetJobsIDDefinitionHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundPutJobsIDDefinitionHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewPutJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -241,7 +241,7 @@ func TestNorthboundPutJobsIDDefinitionHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundPutJobsIDDefinitionHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPutJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -255,7 +255,7 @@ func TestNorthboundPutJobsIDDefinitionHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetWorkflowsNameHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetWorkflowsNameParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -269,7 +269,7 @@ func TestNorthboundGetWorkflowsNameHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetWorkflowsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -283,7 +283,7 @@ func TestNorthboundGetWorkflowsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetWorkflowsHandler_Empty(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewGetWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -297,7 +297,7 @@ func TestNorthboundGetWorkflowsHandler_Empty(t *testing.T) {
 }
 
 func TestNorthboundDeleteWorkflowsNameHandle_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewDeleteWorkflowsNameParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -311,7 +311,7 @@ func TestNorthboundDeleteWorkflowsNameHandle_NotFound(t *testing.T) {
 }
 
 func TestNorthboundDeleteWorkflowsNameHandle_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewDeleteWorkflowsNameParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -325,7 +325,7 @@ func TestNorthboundDeleteWorkflowsNameHandle_InternalError(t *testing.T) {
 }
 
 func TestNorthboundPostWorkflowsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPostWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -340,7 +340,7 @@ func TestNorthboundPostWorkflowsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundPostWorkflowsHandler_AlreadyExists(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{alreadyExists: true})
+	api := NewNorthboundAPI(&faultyStorage{alreadyExists: true})
 
 	params := northbound.NewPostWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -355,7 +355,7 @@ func TestNorthboundPostWorkflowsHandler_AlreadyExists(t *testing.T) {
 }
 
 func TestNorthboundPostWorkflowsHandler_InvalidWorkflow(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPostWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -370,7 +370,7 @@ func TestNorthboundPostWorkflowsHandler_InvalidWorkflow(t *testing.T) {
 }
 
 func TestNorthboundPostJobsHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewPostJobsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -385,7 +385,7 @@ func TestNorthboundPostJobsHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundPostJobsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPostJobsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -400,7 +400,7 @@ func TestNorthboundPostJobsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundDeleteJobsIDHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewDeleteJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -414,7 +414,7 @@ func TestNorthboundDeleteJobsIDHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundDeleteJobsIDHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewDeleteJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -428,7 +428,7 @@ func TestNorthboundDeleteJobsIDHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDTagsHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewGetJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -442,7 +442,7 @@ func TestNorthboundGetJobsIDTagsHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundGetJobsIDTagsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewGetJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -456,7 +456,7 @@ func TestNorthboundGetJobsIDTagsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundPostJobsIDTagsHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewPostJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -470,7 +470,7 @@ func TestNorthboundPostJobsIDTagsHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundPostJobsIDTagsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewPostJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -484,7 +484,7 @@ func TestNorthboundPostJobsIDTagsHandler_InternalError(t *testing.T) {
 }
 
 func TestNorthboundDeleteJobsIDTagsHandler_NotFound(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{notFound: true})
+	api := NewNorthboundAPI(&faultyStorage{notFound: true})
 
 	params := northbound.NewDeleteJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -498,7 +498,7 @@ func TestNorthboundDeleteJobsIDTagsHandler_NotFound(t *testing.T) {
 }
 
 func TestNorthboundDeleteJobsIDTagsHandler_InternalError(t *testing.T) {
-	api, _ := NewNorthboundAPI(&faultyStorage{})
+	api := NewNorthboundAPI(&faultyStorage{})
 
 	params := northbound.NewDeleteJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))

--- a/api/southbound.go
+++ b/api/southbound.go
@@ -11,7 +11,6 @@ package api
 import (
 	"net/http"
 
-	"github.com/Southclaws/fault"
 	"github.com/Southclaws/fault/ftag"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
@@ -28,11 +27,10 @@ import (
 	"github.com/siemens/wfx/persistence"
 )
 
-func NewSouthboundAPI(storage persistence.Storage) (*operations.WorkflowExecutorAPI, error) {
-	swaggerSpec, err := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
-	if err != nil {
-		return nil, fault.Wrap(err)
-	}
+func NewSouthboundAPI(storage persistence.Storage) *operations.WorkflowExecutorAPI {
+	// NOTE: loads.Embedded only fails when given invalid JSON input; in our
+	// context, the JSON is always valid, so we may safely ignore the error.
+	swaggerSpec, _ := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	serverAPI := operations.NewWorkflowExecutorAPI(swaggerSpec)
 
 	serverAPI.SouthboundGetJobsHandler = southbound.GetJobsHandlerFunc(
@@ -176,5 +174,5 @@ func NewSouthboundAPI(storage persistence.Storage) (*operations.WorkflowExecutor
 			return southbound.NewGetJobsIDTagsOK().WithPayload(tags)
 		})
 
-	return serverAPI, nil
+	return serverAPI
 }

--- a/api/southbound_test.go
+++ b/api/southbound_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSouthboundGetJobsIDStatusHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewGetJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -35,7 +35,7 @@ func TestSouthboundGetJobsIDStatusHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundPutJobsIDStatusHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewPutJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -50,7 +50,7 @@ func TestSouthboundPutJobsIDStatusHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundGetJobsHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetJobsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -64,7 +64,7 @@ func TestSouthboundGetJobsHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewGetJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -78,7 +78,7 @@ func TestSouthboundGetJobsIDHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetJobsIDParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -94,7 +94,7 @@ func TestSouthboundGetJobsIDHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDStatusHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -108,7 +108,7 @@ func TestSouthboundGetJobsIDStatusHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundPutJobsIDStatusHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewPutJobsIDStatusParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -122,7 +122,7 @@ func TestSouthboundPutJobsIDStatusHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDDefinitionHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewGetJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -136,7 +136,7 @@ func TestSouthboundGetJobsIDDefinitionHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDDefinitionHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -150,7 +150,7 @@ func TestSouthboundGetJobsIDDefinitionHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundPutJobsIDDefinitionHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewPutJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -164,7 +164,7 @@ func TestSouthboundPutJobsIDDefinitionHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundPutJobsIDDefinitionHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewPutJobsIDDefinitionParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -178,7 +178,7 @@ func TestSouthboundPutJobsIDDefinitionHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetWorkflowsNameHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetWorkflowsNameParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -192,7 +192,7 @@ func TestSouthboundGetWorkflowsNameHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetWorkflowsHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -206,7 +206,7 @@ func TestSouthboundGetWorkflowsHandler_InternalError(t *testing.T) {
 }
 
 func TestSouthboundGetWorkflowsHandler_Empty(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewGetWorkflowsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -220,7 +220,7 @@ func TestSouthboundGetWorkflowsHandler_Empty(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDTagsHandler_NotFound(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{notFound: true})
+	api := NewSouthboundAPI(&faultyStorage{notFound: true})
 
 	params := southbound.NewGetJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))
@@ -234,7 +234,7 @@ func TestSouthboundGetJobsIDTagsHandler_NotFound(t *testing.T) {
 }
 
 func TestSouthboundGetJobsIDTagsHandler_InternalError(t *testing.T) {
-	api, _ := NewSouthboundAPI(&faultyStorage{})
+	api := NewSouthboundAPI(&faultyStorage{})
 
 	params := southbound.NewGetJobsIDTagsParams()
 	params.HTTPRequest = httptest.NewRequest(http.MethodGet, "http://localhost", new(bytes.Buffer))

--- a/api/workflow_test.go
+++ b/api/workflow_test.go
@@ -199,13 +199,11 @@ func newInMemoryDB(t *testing.T) persistence.Storage {
 }
 
 func createNorthAndSouth(t *testing.T, db persistence.Storage) (http.Handler, http.Handler) {
-	northAPI, err := NewNorthboundAPI(db)
-	require.NoError(t, err)
+	northAPI := NewNorthboundAPI(db)
 	require.NoError(t, northAPI.Validate())
 	north := northbound.ConfigureAPI(northAPI)
 
-	southAPI, err := NewSouthboundAPI(db)
-	require.NoError(t, err)
+	southAPI := NewSouthboundAPI(db)
 	require.NoError(t, southAPI.Validate())
 	south := southbound.ConfigureAPI(southAPI)
 

--- a/cmd/wfx/cmd/root/cmd_test.go
+++ b/cmd/wfx/cmd/root/cmd_test.go
@@ -11,8 +11,11 @@ package root
  */
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -22,6 +25,7 @@ import (
 	"github.com/knadh/koanf/v2"
 	"github.com/rs/zerolog"
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,6 +98,122 @@ func TestCommand_ReloadConfig(t *testing.T) {
 
 	wg.Wait()
 	require.NoError(t, err)
+}
+
+func TestAdoptListeners(t *testing.T) {
+	assert.Empty(t, adoptListeners(nil, nil))
+	assert.Empty(t, adoptListeners([]net.Listener{nil, nil, nil}, nil))
+
+	sock1, _ := os.CreateTemp(os.TempDir(), "TestAdoptListeners*.sock")
+	sock2, _ := os.CreateTemp(os.TempDir(), "TestAdoptListeners*.sock")
+	t.Cleanup(func() {
+		_ = os.Remove(sock1.Name())
+		_ = os.Remove(sock2.Name())
+	})
+
+	ln1, _ := net.Listen("unix", sock1.Name())
+	ln2, _ := net.Listen("unix", sock1.Name())
+
+	collection := adoptListeners([]net.Listener{ln1, ln2}, nil)
+	t.Cleanup(func() {
+		for _, sc := range collection {
+			sc.Shutdown(context.Background())
+		}
+	})
+	assert.Len(t, collection, 2)
+	assert.Len(t, collection[0].servers, 1)
+	assert.Len(t, collection[1].servers, 1)
+
+	actualLn1, err := collection[0].servers[0].Listener()
+	assert.Nil(t, err)
+	assert.Equal(t, ln1, actualLn1)
+
+	actualLn2, err := collection[1].servers[0].Listener()
+	assert.Nil(t, err)
+	assert.Equal(t, ln2, actualLn2)
+}
+
+func TestLaunchServer_ListenerError(t *testing.T) {
+	srv := myServer{
+		Listener: func() (net.Listener, error) {
+			return nil, errors.New("something went wrong")
+		},
+	}
+	err := launchServer("test", srv)
+	assert.NotNil(t, err)
+}
+
+func TestLaunchServer_UDS(t *testing.T) {
+	f, _ := os.CreateTemp(os.TempDir(), "TestLaunchServer_UDS.*.sock")
+	f.Close()
+	_ = os.Remove(f.Name())
+	ln, err := net.Listen("unix", f.Name())
+	require.NoError(t, err)
+
+	srv := myServer{
+		Srv: &http.Server{Handler: http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})},
+		Listener: func() (net.Listener, error) {
+			return ln, nil
+		},
+		Kind: kindUnix,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := launchServer("notls", srv)
+		assert.NoError(t, err)
+	}()
+
+	for i := 0; i < 30; i++ {
+		time.Sleep(time.Millisecond * 10)
+		conn, err := net.Dial("unix", f.Name())
+		if err != nil {
+			continue
+		}
+		defer conn.Close()
+
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		client := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return conn, nil
+				},
+			},
+		}
+		resp, err := client.Do(req)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			break
+		}
+	}
+
+	_ = srv.Srv.Shutdown(context.Background())
+	wg.Wait()
+}
+
+func TestLaunchServer_ListenerClosed(t *testing.T) {
+	f, _ := os.CreateTemp(os.TempDir(), "TestLaunchServer_UDS.*.sock")
+	f.Close()
+	_ = os.Remove(f.Name())
+	ln, _ := net.Listen("unix", f.Name())
+	_ = ln.Close()
+
+	srv := myServer{
+		Srv: &http.Server{Handler: http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})},
+		Listener: func() (net.Listener, error) {
+			return ln, nil
+		},
+		Kind: kindUnix,
+	}
+
+	err := launchServer("notls", srv)
+	assert.Error(t, err)
 }
 
 func waitForLogLevel(t *testing.T, expected zerolog.Level) {

--- a/cmd/wfx/cmd/root/northbound.go
+++ b/cmd/wfx/cmd/root/northbound.go
@@ -10,7 +10,6 @@ package root
 
 import (
 	"github.com/Southclaws/fault"
-	"github.com/Southclaws/fault/fmsg"
 	"github.com/knadh/koanf/v2"
 	"github.com/rs/cors"
 	"github.com/siemens/wfx/api"
@@ -35,11 +34,7 @@ func createNorthboundCollection(schemes []string, storage persistence.Storage) (
 		settings.TLSPort = k.Int(mgmtTLSPortFlag)
 		settings.UDSPath = k.String(mgmtUnixSocketFlag)
 	})
-	api, err := api.NewNorthboundAPI(storage)
-	if err != nil {
-		return nil, fault.Wrap(err, fmsg.With("Failed to create northbound API"))
-	}
-
+	api := api.NewNorthboundAPI(storage)
 	fsMW, err := fileserver.NewFileServerMiddleware(k)
 	if err != nil {
 		return nil, fault.Wrap(err)

--- a/cmd/wfx/cmd/root/southbound.go
+++ b/cmd/wfx/cmd/root/southbound.go
@@ -10,7 +10,6 @@ package root
 
 import (
 	"github.com/Southclaws/fault"
-	"github.com/Southclaws/fault/fmsg"
 	"github.com/knadh/koanf/v2"
 	"github.com/rs/cors"
 	"github.com/siemens/wfx/api"
@@ -35,10 +34,7 @@ func createSouthboundCollection(schemes []string, storage persistence.Storage) (
 		settings.TLSPort = k.Int(clientTLSPortFlag)
 		settings.UDSPath = k.String(clientUnixSocket)
 	})
-	api, err := api.NewSouthboundAPI(storage)
-	if err != nil {
-		return nil, fault.Wrap(err, fmsg.With("Failed to create southbound API"))
-	}
+	api := api.NewSouthboundAPI(storage)
 
 	fsMW, err := fileserver.NewFileServerMiddleware(k)
 	if err != nil {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Siemens AG
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Michael Adler <michael.adler@siemens.com>
+
+# This file can be validated as follows:
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 10% # the leniency in hitting the target

--- a/internal/errutil/main_test.go
+++ b/internal/errutil/main_test.go
@@ -1,0 +1,19 @@
+package errutil
+
+/*
+ * SPDX-FileCopyrightText: 2023 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/errutil/wrap.go
+++ b/internal/errutil/wrap.go
@@ -1,0 +1,17 @@
+package errutil
+
+/*
+ * SPDX-FileCopyrightText: 2023 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import "github.com/Southclaws/fault"
+
+// Wrap2 wraps the provided error using fault.Wrap and returns
+// the original value along with the wrapped error.
+func Wrap2[T any](value T, err error) (T, error) {
+	return value, fault.Wrap(err)
+}

--- a/internal/errutil/wrap_test.go
+++ b/internal/errutil/wrap_test.go
@@ -1,0 +1,38 @@
+package errutil
+
+/*
+ * SPDX-FileCopyrightText: 2023 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrap2(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no error", func(t *testing.T) {
+		val, err := Wrap2("foo", nil)
+		assert.Equal(t, "foo", val)
+		assert.Nil(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		val, err := Wrap2[any](nil, errors.New("test"))
+		assert.Nil(t, val)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("both", func(t *testing.T) {
+		val, err := Wrap2("foo", errors.New("test"))
+		assert.Equal(t, "foo", val)
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
### Description

wfx now promptly shuts down upon receiving signals, such as CTRL-C. Previously, it might enter a loop if its listening port was unavailable, rendering it unresponsive to signals during that period.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
