### PR TITLE
fix: filter wfxctl job query by group

### DIFF
--- a/cmd/wfxctl/cmd/job/query/query.go
+++ b/cmd/wfxctl/cmd/job/query/query.go
@@ -31,7 +31,7 @@ const (
 func init() {
 	f := Command.Flags()
 	f.String(clientIDFlag, "", "Filter jobs belonging to a specific client with clientId")
-	f.String(groupFlag, "", "Filter jobs based on the group they belong to")
+	f.StringSlice(groupFlag, []string{}, "Filter jobs based on the group they belong to")
 	f.String(stateFlag, "", "Filter jobs based on the current state value")
 	f.String(workflowFlag, "", "Filter jobs based on workflow name")
 	f.StringSlice(tagFlag, []string{}, "Filter jobs by tags")


### PR DESCRIPTION
### Description

Fix wfxctl --group filtering option so it correctly accepts a list of group names.
Currently the group filter is ignored because of the wrong type of the argument.
Add bash CLI tests for wfxctl --group option.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
