### PR TITLE
refactor!: `wfxctl workflow delete` to accept workflows as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored `wfxctl workflow delete` command to accept workflows as arguments instead of positional parameters
+
 ### Removed
 
 ## [0.1.0] - 2023-02-06

--- a/api/northbound.go
+++ b/api/northbound.go
@@ -9,6 +9,7 @@ package api
  */
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/Southclaws/fault/ftag"
@@ -169,7 +170,9 @@ func NewNorthboundAPI(storage persistence.Storage) *operations.WorkflowExecutorA
 			if err != nil {
 				switch ftag.Get(err) {
 				case ftag.NotFound:
-					return northbound.NewDeleteWorkflowsNameNotFound()
+					err2 := WorkflowNotFound
+					err2.Message = fmt.Sprintf("Workflow '%s' not found", params.Name)
+					return northbound.NewDeleteWorkflowsNameNotFound().WithPayload(&model.ErrorResponse{Errors: []*model.Error{&err2}})
 				default:
 					return northbound.NewDeleteWorkflowsNameDefault(http.StatusInternalServerError)
 				}

--- a/cmd/wfxctl/cmd/workflow/delete/delete_test.go
+++ b/cmd/wfxctl/cmd/workflow/delete/delete_test.go
@@ -36,7 +36,7 @@ func TestDeleteWorkflow(t *testing.T) {
 	port, _ := strconv.Atoi(u.Port())
 	_ = flags.Koanf.Set(flags.MgmtPortFlag, port)
 
-	_ = flags.Koanf.Set(nameFlag, "wfx.workflow.dau.direct")
+	Command.SetArgs([]string{"wfx.workflow.dau.direct"})
 
 	err := Command.Execute()
 	assert.NoError(t, err)


### PR DESCRIPTION
### Description

- Change `wfxctl workflow delete` to take workflows as arguments rather than positional parameters
- Return a descriptive error message along with a 404 status code if the specified workflow is not found

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
