### PR TITLE
style: suppress error logging for non-existent workflows

### DIFF
--- a/internal/handler/workflow/get.go
+++ b/internal/handler/workflow/get.go
@@ -12,18 +12,24 @@ import (
 	"context"
 
 	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/ftag"
 	"github.com/siemens/wfx/generated/model"
 	"github.com/siemens/wfx/middleware/logging"
 	"github.com/siemens/wfx/persistence"
 )
 
 func GetWorkflow(ctx context.Context, storage persistence.Storage, name string) (*model.Workflow, error) {
-	log := logging.LoggerFromCtx(ctx)
+	log := logging.LoggerFromCtx(ctx).With().Str("name", name).Logger()
 	log.Debug().Str("name", name).Msg("Fetching workflow")
 	workflow, err := storage.GetWorkflow(ctx, name)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to get workflow from persistence storage")
+		if ftag.Get(err) == ftag.NotFound {
+			log.Debug().Msg("Workflow not found")
+		} else {
+			log.Error().Err(err).Msg("Failed to get workflow from storage")
+		}
 		return nil, fault.Wrap(err)
 	}
+	log.Debug().Msg("Found workflow")
 	return workflow, nil
 }

--- a/internal/handler/workflow/get_test.go
+++ b/internal/handler/workflow/get_test.go
@@ -10,8 +10,12 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/ftag"
+	"github.com/siemens/wfx/persistence"
 	"github.com/siemens/wfx/workflow/dau"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,4 +29,26 @@ func TestGetWorkflow(t *testing.T) {
 	wf2, err := GetWorkflow(context.Background(), db, wf.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, wf.Name, wf2.Name)
+}
+
+func TestGetWorkflow_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	db := persistence.NewMockStorage(t)
+	db.EXPECT().GetWorkflow(ctx, "foo").Return(nil, fault.Wrap(errors.New("Not found"), ftag.With(ftag.NotFound)))
+
+	wf, err := GetWorkflow(ctx, db, "foo")
+	assert.Nil(t, wf)
+	assert.NotNil(t, err)
+}
+
+func TestGetWorkflow_Internal(t *testing.T) {
+	ctx := context.Background()
+
+	db := persistence.NewMockStorage(t)
+	db.EXPECT().GetWorkflow(ctx, "foo").Return(nil, fault.Wrap(errors.New("Not found"), ftag.With(ftag.Internal)))
+
+	wf, err := GetWorkflow(ctx, db, "foo")
+	assert.Nil(t, wf)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
### Description

Logging errors should be reserved for situations warranting further investigation, such as issues with the persistent storage. A query for a (not yet) existing workflow is not an exceptional case and should not trigger error logging. This commit removes the unnecessary logging of such events.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
