### PR TITLE
ci: pin entgo version for stable codegen

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,9 +104,10 @@ _generate-swagger:
 _generate-ent:
     #!/usr/bin/env bash
     set -euxo pipefail
+    ENT_VERSION=$(grep entgo.io/ent "{{ THISDIR }}/go.mod" | awk -F' ' '{ print $2; }')
     cd "{{ THISDIR }}/generated/ent"
     find . -not -name generate.go -and -not -name main.go -and -not -path "**/schema/*" -type f -delete
-    go run entgo.io/ent/cmd/ent@latest generate --header \
+    go run entgo.io/ent/cmd/ent@${ENT_VERSION} generate --header \
         "// SPDX-FileCopyrightText: The entgo authors
          // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Description

The current "latest is greatest" approach breaks our CI pipelines forcing us to upgrade entgo as soon as a new version has been released. We use dependabot to keep our dependencies updated though.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
