### PR TITLE
chore: integrate automaxprocs/maxprocs with zerolog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+- Log messages from automaxprocs/maxprocs are now seamlessly integrated into existing logging framework
+
+### Removed
+
+## [0.2.0] - 2024-01-15
+
+### Added
+
 - Add optional `description` field to workflows
 - Job event notifications via server-sent events (see #11)
 - Plugin System for External Middlewares (see #43)
@@ -32,5 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release of wfx.
 
-[unreleased]: https://github.com/siemens/wfx/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/siemens/wfx/releases/tag/v0.1.0
+[0.2.0]: https://github.com/siemens/wfx/releases/tag/v0.2.0
+[unreleased]: https://github.com/siemens/wfx/compare/v0.2.0...HEAD

--- a/cmd/wfx/cmd/root/cmd.go
+++ b/cmd/wfx/cmd/root/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/siemens/wfx/persistence"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 var k = config.New()
@@ -101,6 +102,9 @@ Examples of tasks are installation of firmware or other types of commands issued
 			logFormat = k.String(logFormatFlag)
 		})
 		setupLogging(os.Stdout, logFormat, logLevel)
+		if _, err := maxprocs.Set(maxprocs.Logger(log.Printf)); err != nil {
+			log.Warn().Err(err).Msg("Failed to set GOMAXPROCS")
+		}
 
 		// start watching config
 		if fileProvider != nil {

--- a/cmd/wfx/main.go
+++ b/cmd/wfx/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"github.com/rs/zerolog/log"
-	_ "go.uber.org/automaxprocs"
 
 	"github.com/siemens/wfx/cmd/wfx/cmd/root"
 	"github.com/siemens/wfx/cmd/wfx/metadata"


### PR DESCRIPTION
### Description

Log messages from automaxprocs/maxprocs are now seamlessly integrated into our existing logging framework.
Previously, automaxprocs/maxprocs relied solely on `printf` for outputting messages directly to stdout. This approach bypassed any user-defined log levels, leading to potential issues in log verbosity and management.
 
#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
