### PR TITLE
fix: include workflow definition in response when creating jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Compilation for Windows (not officially supported though)
+- Include workflow definition in response when creating jobs
 
 ### Changed
 

--- a/internal/handler/job/create_test.go
+++ b/internal/handler/job/create_test.go
@@ -31,6 +31,8 @@ func TestCreateJob(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, job.Status.DefinitionHash)
+	require.NotNil(t, job.Workflow)
+	assert.Equal(t, wf.Name, job.Workflow.Name)
 }
 
 func TestCreateJob_Notification(t *testing.T) {

--- a/internal/persistence/entgo/job_create.go
+++ b/internal/persistence/entgo/job_create.go
@@ -65,7 +65,8 @@ func createJobHelper(ctx context.Context, tx *ent.Tx, job *model.Job) (*model.Jo
 		log.Error().Err(err).Msg("Failed to fetch workflow from database")
 		return nil, fault.Wrap(err)
 	}
-	group := wfutil.FindStateGroup(convertWorkflow(wfEntity), job.Status.State)
+	wf := convertWorkflow(wfEntity)
+	group := wfutil.FindStateGroup(wf, job.Status.State)
 
 	// start tags
 	n := len(job.Tags)
@@ -135,8 +136,8 @@ func createJobHelper(ctx context.Context, tx *ent.Tx, job *model.Job) (*model.Jo
 	}
 
 	result := convertJob(entity)
-	// tags are not fetched by entgo, so we have to add them manually
+	// tags and workflow are not fetched by entgo, so we have to add them manually
 	result.Tags = job.Tags
-
+	result.Workflow = wf
 	return result, nil
 }


### PR DESCRIPTION
### Description

When querying one or multiple jobs, the response always includes the workflow definition. However, this was not the case when creating a new job; the response omitted the workflow definition. This inconsistency not only diverged from our established response behavior but also from the examples generated in our Swagger documentation. This change ensures that the response for newly created jobs includes the workflow definition, aligning it with our existing standards and documentation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [X] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
