### PR TITLE
docs: clarify when the job history is included in responses

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -106,8 +106,14 @@ After a job has been created, its `definition`, `status`, and `tags` can be upda
 the changes. To simplify things for client authors, wfx automatically updates the `status.definitionHash` whenever the
 `definition` changes. This provides a mechanism for detecting changes in the `definition`.
 
-wfx stores the previous `status` of the job, as well as the previous `definition`, in the job `history` array. This
-allows reviewing job updates later on and diagnose problems.
+### Job History
+
+Whenever a job's `status` or `definition` changes, wfx prepends the current value to the job's `history` array.
+This allows for reviewing job updates later on and diagnosing problems.
+
+**Note**: By default, the job history is omitted from all `Job` responses, primarily due to its diagnostic nature but
+also for bandwidth reasons. Clients requiring a job's historical data must explicitly request the specific job and
+include the `history=true` parameter in their request.
 
 ### Deleting Jobs
 

--- a/generated/model/job.go
+++ b/generated/model/job.go
@@ -34,6 +34,8 @@ type Job struct {
 	Definition map[string]interface{} `json:"definition,omitempty"`
 
 	// The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.
+	// By default, the job history is omitted from responses unless explicitly requested by the client (see the `history` URL parameter).
+	//
 	// Max Items: 8192
 	History []*History `json:"history,omitempty"`
 

--- a/generated/northbound/restapi/embedded_spec.go
+++ b/generated/northbound/restapi/embedded_spec.go
@@ -1164,7 +1164,7 @@ func init() {
           "example": "{ \"userDefined\": {} }\n"
         },
         "history": {
-          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.",
+          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.\nBy default, the job history is omitted from responses unless explicitly requested by the client (see the ` + "`" + `history` + "`" + ` URL parameter).\n",
           "type": "array",
           "maxItems": 8192,
           "items": {
@@ -2885,7 +2885,7 @@ func init() {
           "example": "{ \"userDefined\": {} }\n"
         },
         "history": {
-          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.",
+          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.\nBy default, the job history is omitted from responses unless explicitly requested by the client (see the ` + "`" + `history` + "`" + ` URL parameter).\n",
           "type": "array",
           "maxItems": 8192,
           "items": {

--- a/generated/southbound/restapi/embedded_spec.go
+++ b/generated/southbound/restapi/embedded_spec.go
@@ -1164,7 +1164,7 @@ func init() {
           "example": "{ \"userDefined\": {} }\n"
         },
         "history": {
-          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.",
+          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.\nBy default, the job history is omitted from responses unless explicitly requested by the client (see the ` + "`" + `history` + "`" + ` URL parameter).\n",
           "type": "array",
           "maxItems": 8192,
           "items": {
@@ -2885,7 +2885,7 @@ func init() {
           "example": "{ \"userDefined\": {} }\n"
         },
         "history": {
-          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.",
+          "description": "The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.\nBy default, the job history is omitted from responses unless explicitly requested by the client (see the ` + "`" + `history` + "`" + ` URL parameter).\n",
           "type": "array",
           "maxItems": 8192,
           "items": {

--- a/spec/wfx.swagger.yml
+++ b/spec/wfx.swagger.yml
@@ -290,7 +290,9 @@ definitions:
         readOnly: true
         x-nullable: true
       history:
-        description: The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.
+        description: |
+          The job's history. Last in, first out (LIFO). Array is truncated if its length exceeds the maximum allowed length.
+          By default, the job history is omitted from responses unless explicitly requested by the client (see the `history` URL parameter).
         type: array
         x-omitempty: true
         <<: *maxHistoryCount


### PR DESCRIPTION
### Description

The purpose of this merge request is to clarify when the job history is included in responses.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
