### PR TITLE
fix(Makefile): Use invoking make in Makefile's make calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ALL_TARGETS := wfx wfxctl wfx-viewer wfx-loadtest
 
 .PHONY: default
 default:
-	@make -s $(ALL_TARGETS)
+	@$(MAKE) -s $(ALL_TARGETS)
 
 .PHONY: test
 test:
@@ -52,8 +52,8 @@ plugins:
 
 .PHONY: contrib
 contrib:
-	make -s -C contrib/remote-access
-	make -s -C contrib/config-deployment
+	$(MAKE) -s -C contrib/remote-access
+	$(MAKE) -s -C contrib/config-deployment
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Use the invoking `make` for make calls in Makefile, see https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html

This fixes compilation on BSDs where GNU make is usually installed as `gmake`.

### Description

#### Issues Addressed

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
