### PR TITLE
ci: exclude loadtest and viewer from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,10 @@ ignore:
   - "**/mock_*.go"
   # exclude generated code
   - "generated/**"
+  # exclude test code
+  - "cmd/wfx-loadtest/**"
+  # TODO: would be nice to have some tests even if it's just a dev tool
+  - "cmd/wfx-viewer/**"
 
 coverage:
   status:


### PR DESCRIPTION
This commit excludes both the loadtest and viewer modules from coverage data collected by codecov. A recent change in Codecov's behavior has unexpectedly included these modules in coverage tracking. While there may be an opportunity to implement tests for wfx-viewer in the future, the primary objective of this commit is to revert the code coverage metrics to their original state.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
