### PR TITLE
feat: improve error message when trying to use disabled plugin feature

### DIFF
--- a/cmd/wfx/cmd/root/plugins.go
+++ b/cmd/wfx/cmd/root/plugins.go
@@ -24,21 +24,6 @@ import (
 	"github.com/siemens/wfx/middleware/plugin"
 )
 
-const (
-	clientPluginsDirFlag = "client-plugins-dir"
-	mgmtPluginsDirFlag   = "mgmt-plugins-dir"
-)
-
-func init() {
-	f := Command.PersistentFlags()
-
-	_ = Command.MarkPersistentFlagDirname(clientPluginsDirFlag)
-	f.String(clientPluginsDirFlag, "", "directory containing client plugins")
-
-	_ = Command.MarkPersistentFlagDirname(mgmtPluginsDirFlag)
-	f.String(mgmtPluginsDirFlag, "", "directory containing management plugins")
-}
-
 func LoadNorthboundPlugins(chQuit chan error) ([]middleware.IntermediateMW, error) {
 	return loadPluginSet(mgmtPluginsDirFlag, chQuit)
 }

--- a/cmd/wfx/cmd/root/plugins_disabled.go
+++ b/cmd/wfx/cmd/root/plugins_disabled.go
@@ -10,12 +10,16 @@ package root
  * Author: Michael Adler <michael.adler@siemens.com>
  */
 
-import "github.com/siemens/wfx/middleware"
+import (
+	"errors"
+
+	"github.com/siemens/wfx/middleware"
+)
 
 func LoadNorthboundPlugins(chan error) ([]middleware.IntermediateMW, error) {
-	return []middleware.IntermediateMW{}, nil
+	return nil, errors.New("this binary was built without plugin support")
 }
 
 func LoadSouthboundPlugins(chan error) ([]middleware.IntermediateMW, error) {
-	return []middleware.IntermediateMW{}, nil
+	return nil, errors.New("this binary was built without plugin support")
 }

--- a/cmd/wfx/cmd/root/plugins_disabled_test.go
+++ b/cmd/wfx/cmd/root/plugins_disabled_test.go
@@ -1,0 +1,29 @@
+//go:build !plugin
+
+package root
+
+/*
+ * SPDX-FileCopyrightText: 2023 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadNorthboundPlugins(t *testing.T) {
+	mw, err := LoadNorthboundPlugins(nil)
+	assert.Nil(t, mw)
+	assert.ErrorContains(t, err, "this binary was built without plugin support")
+}
+
+func TestLoadSouthboundPlugins(t *testing.T) {
+	mw, err := LoadSouthboundPlugins(nil)
+	assert.Nil(t, mw)
+	assert.ErrorContains(t, err, "this binary was built without plugin support")
+}

--- a/cmd/wfx/cmd/root/plugins_flag.go
+++ b/cmd/wfx/cmd/root/plugins_flag.go
@@ -1,0 +1,24 @@
+package root
+
+/*
+ * SPDX-FileCopyrightText: 2024 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+const (
+	clientPluginsDirFlag = "client-plugins-dir"
+	mgmtPluginsDirFlag   = "mgmt-plugins-dir"
+)
+
+func init() {
+	f := Command.PersistentFlags()
+
+	_ = Command.MarkPersistentFlagDirname(clientPluginsDirFlag)
+	f.String(clientPluginsDirFlag, "", "directory containing client plugins")
+
+	_ = Command.MarkPersistentFlagDirname(mgmtPluginsDirFlag)
+	f.String(mgmtPluginsDirFlag, "", "directory containing management plugins")
+}


### PR DESCRIPTION
The plugin feature can be disabled at compile-time. Previously, attempting to use the `--client-plugins-dir` or `--mgmt-plugins-dir` flags without plugin support compiled into the wfx binary resulted in a generic "unknown flags" error. This commit introduces a more informative error message, explicitly stating that wfx was built without plugin support, improving clarity for end users and aiding in troubleshooting.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
