### PR TITLE
fix: asset integrity hash generation in hugo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: latest
+          # note: hugo >= 0.123.0 and <= 0.123.6 is broken for us
+          hugo-version: "0.122.0"
           extended: true
 
       - name: Setup Node
@@ -47,7 +48,9 @@ jobs:
       - run: just check-md-links
 
       - run: cd hugo && npm ci
-      - run: env HUGO_BASEURL=https://siemens.github.io/wfx/ just pages
+      - run: just pages
+        env:
+          HUGO_BASEURL: ${{ vars.HUGO_BASEURL }}
       - run: ls -al public/
 
       - name: Deploy


### PR DESCRIPTION
This commit addresses a critical issue where Hugo versions between 0.123.0 and 0.123.6 generate incorrect integrity hashes for static assets (such as JavaScript files).
The workaround is to pin Hugo's version to a previously stable version that does not exhibit this problem.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
