### PR TITLE
chore(deps): pin markdown-link-check@3.11.2

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
       - run: sudo apt-get update -q && sudo apt-get install -y --no-install-recommends make imagemagick librsvg2-bin
 
       # check for broken links
-      - run: sudo npm install -g markdown-link-check
+      - run: sudo npm install -g markdown-link-check@3.11.2
       - run: just check-md-links
 
       - run: cd hugo && npm ci


### PR DESCRIPTION
Pin markdown-link-check to version 3.11.2 until https://github.com/tcort/markdown-link-check/issues/304 is resolved in the 3.12.x series.

### Description

Current markdown link check fails due to a regression in 3.12.x

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
