### PR TITLE
chore: update docsy and hugo

### DIFF
--- a/.ci/packages/versions.env
+++ b/.ci/packages/versions.env
@@ -2,7 +2,7 @@ export FLATBUFFERS_VERSION=24.3.25 # github-releases/google/flatbuffers&versioni
 export GOFUMPT_VERSION=0.6.0 # github-releases/mvdan/gofumpt&versioning=semver
 export GOLANGCI_LINT_VERSION=1.58.2 # github-releases/golangci/golangci-lint&versioning=semver
 export GORELEASER_VERSION=1.26.1 # github-releases/goreleaser/goreleaser&versioning=semver
-export HUGO_VERSION=0.122.0 # github-releases/gohugoio/hugo&versioning=semver
+export HUGO_VERSION=0.127.0 # github-releases/gohugoio/hugo&versioning=semver
 export JUST_VERSION=1.26.0 # github-releases/casey/just&versioning=semver
 export MOCKERY_VERSION=2.42.1 # github-releases/vektra/mockery&versioning=semver
 export PANDOC_VERSION=3.2 # github-releases/jgm/pandoc&versioning=semver

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - run: just pages
         env:
           HUGO_BASEURL: ${{ vars.HUGO_BASEURL }}
-      - run: ls -al public/
+      - run: find public
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Siemens AG
 #
 # SPDX-License-Identifier: Apache-2.0
-canonifyURLs = true
 
 contentDir = "content"
 defaultContentLanguage = "en"
@@ -64,7 +63,7 @@ prism_syntax_highlighting = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 # Set to true to disable the About link in the site footer
-footer_about_disable = false
+footer_about_enable = true
 # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top navbar
 navbar_logo = true
 # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.
@@ -99,6 +98,9 @@ enable = false
   url = "https://opensource.siemens.com/"
   icon = "fa fa-heart"
   desc = "Siemens loves Open Source!"
+
+[security.gotemplates]
+allowActionJSTmpl = true
 
 # hugo module configuration
 

--- a/hugo/content/_index.html
+++ b/hugo/content/_index.html
@@ -6,7 +6,7 @@ linkTitle = "wfx"
 
 {{< blocks/cover title="" image_anchor="top" height="full" color="primary" >}}
 <div class="mx-auto">
-  <img src="/images/logo.svg" />
+  <img src="./images/logo.svg" />
   <br /><br /><br />
   <a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
     Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>

--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -3,6 +3,6 @@ module github.com/siemens/wfx
 go 1.22
 
 require (
-	github.com/google/docsy v0.9.1 // indirect
+	github.com/google/docsy v0.10.0 // indirect
 	github.com/google/docsy/dependencies v0.7.2 // indirect
 )

--- a/hugo/go.sum
+++ b/hugo/go.sum
@@ -1,6 +1,6 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
-github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
-github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
### Description

This updates to the latest version of docsy and hugo. As it turns out, the option `canonifyURLs` is deprecated and leads to broken links in the latest hugo version, hence I removed it.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
