### PR TITLE
ci(renovate): update indirect deps only for hugo

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,8 +35,7 @@
       matchUpdateTypes: ["minor", "patch", "digest"],
     },
     {
-      // needed to maintain our hugo dependencies
-      matchManagers: ["gomod"],
+      matchFileNames: ["hugo/go.mod"],
       matchDepTypes: ["indirect"],
       enabled: true,
     },


### PR DESCRIPTION
### Description

Updating indirect dependencies in the main go.mod does not make sense as they are not being used and are reverted by running go mod tidy.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
