### PR TITLE
ci: lower codecov severity to informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,9 @@ ignore:
 
 coverage:
   status:
+    project:
+      default:
+        informational: true
     patch:
       default:
         target: auto


### PR DESCRIPTION
Instead of failing the CI pipeline when code coverage slightly decreases, this change sets the codecov severity to informational. This allows the reviewer to assess the coverage changes and make the decision on whether to accept the changes, rather than automatically failing the build. This provides more flexibility and context for the coverage changes.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
