### PR TITLE
refactor: update OpenAPI spec endpoint path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `wfxctl workflow query` now accepts a `sort` param
 - Added (existing but undocumented) `/health` and `/version` endpoint to OpenAPI spec
-- OpenAPI v3 spec is served at `/api/wfx/v1/openapiv3.json`
+- OpenAPI v3 spec is served at `/api/wfx/v1/openapi.json`
 
 ### Fixed
 

--- a/cmd/wfx/cmd/root/root_test.go
+++ b/cmd/wfx/cmd/root/root_test.go
@@ -246,7 +246,7 @@ func TestAPI(t *testing.T) {
 		httpClient := new(http.Client)
 		var spec openapi3.T
 		for i := 0; i < 100; i++ {
-			resp, err := httpClient.Get("http://localhost:8080/api/wfx/v1/openapiv3.json")
+			resp, err := httpClient.Get("http://localhost:8080/api/wfx/v1/openapi.json")
 			if err != nil {
 				time.Sleep(time.Millisecond * 10)
 				continue

--- a/cmd/wfx/cmd/root/server_collection_test.go
+++ b/cmd/wfx/cmd/root/server_collection_test.go
@@ -33,7 +33,7 @@ func TestNewServerCollection(t *testing.T) {
 func TestOpenAPIJSON(t *testing.T) {
 	mux := createMux(new(config.AppConfig), nil)
 	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/wfx/v1/openapiv3.json", nil))
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/wfx/v1/openapi.json", nil))
 	result := rec.Result()
 	assert.Equal(t, http.StatusOK, result.StatusCode)
 }
@@ -45,7 +45,7 @@ func TestTopLevelNotFound(t *testing.T) {
 	result := rec.Result()
 	assert.Equal(t, http.StatusNotFound, result.StatusCode)
 	b, _ := io.ReadAll(result.Body)
-	assert.Equal(t, "The requested resource could not be found.\n\nHint: Check /api/wfx/v1/openapiv3.json to see available endpoints.\n", string(b))
+	assert.Equal(t, "The requested resource could not be found.\n\nHint: Check /api/wfx/v1/openapi.json to see available endpoints.\n", string(b))
 }
 
 func TestDownloadRedirect(t *testing.T) {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,7 +23,7 @@ wfx provides two RESTful APIs to interact with it: the northbound operator/manag
 The northbound API is used to create jobs and execute server-side state transitions, whereas the southbound
 API is used for client-side transitions.
 
-The complete [wfx API specification](../spec/wfx.openapiv3.yml) is accessible at runtime via the `/api/wfx/v1/openapiv3.json` endpoint.
+The complete [wfx API specification](../spec/wfx.openapiv3.yml) is accessible at runtime via the `/api/wfx/v1/openapi.json` endpoint.
 Clients may inspect this specification at run-time so to obey the various limits imposed, e.g, for parameter value ranges and array lengths.
 
 ### Job Events

--- a/spec/openapiv3.go
+++ b/spec/openapiv3.go
@@ -28,7 +28,7 @@ func init() {
 	servers := yamlObj["servers"].([]any)
 	servers2 := servers[0].(map[string]any)
 	basePath := servers2["url"]
-	specEndpoint := fmt.Sprintf("%s/openapiv3.json", basePath)
+	specEndpoint := fmt.Sprintf("%s/openapi.json", basePath)
 
 	jsonData, err := json.Marshal(yamlObj)
 	if err != nil {


### PR DESCRIPTION
Change OpenAPI v3 spec endpoint from /api/wfx/v1/openapiv3.json to /api/wfx/v1/openapi.json. This change aligns with the convention of using openapi.json as the standard name to serve the OpenAPI spec.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
