### PR TITLE
test: Fix paths comparison on macOS

### DIFF
--- a/cmd/wfx/cmd/root/plugins_test.go
+++ b/cmd/wfx/cmd/root/plugins_test.go
@@ -13,6 +13,7 @@ package root
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,9 @@ func TestLoadPlugins(t *testing.T) {
 	plugins, err := loadPlugins(dir)
 	require.NoError(t, err)
 	assert.Len(t, plugins, 1)
-	assert.Equal(t, f.Name(), plugins[0].Name())
+	expected, _ := filepath.EvalSymlinks(f.Name())
+	is, _ := filepath.EvalSymlinks(plugins[0].Name())
+	assert.Equal(t, expected, is)
 }
 
 func TestLoadPluginsIgnoreNonExecutable(t *testing.T) {
@@ -87,7 +90,9 @@ func TestLoadPluginsSymlink(t *testing.T) {
 	plugins, err := loadPlugins(second)
 	require.NoError(t, err)
 	assert.Len(t, plugins, 1)
-	assert.Equal(t, f.Name(), plugins[0].Name())
+	expected, _ := filepath.EvalSymlinks(f.Name())
+	is, _ := filepath.EvalSymlinks(plugins[0].Name())
+	assert.Equal(t, expected, is)
 }
 
 func TestLoadPluginsSymlinkIgnoreNonExecutable(t *testing.T) {


### PR DESCRIPTION
On macOS, `/var` is symlinked to `/private/var` so that `$TMPDIR` != `$(realpath $TMPDIR)`. Hence, compare
fully qualified and symlink-resolved paths.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
