### PR TITLE
ci: integrate oasdiff to detect breaking API changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,19 @@ jobs:
       - run: just generate
       - run: git diff --exit-code
 
+  openapi-check-breaking:
+    name: API check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Check for breaking changes in API
+        id: breaking_changes
+        uses: oasdiff/oasdiff-action/breaking@v0.0.21
+        with:
+          base: https://raw.githubusercontent.com/siemens/wfx/refs/heads/main/spec/wfx.openapiv3.yml
+          revision: spec/wfx.openapiv3.yml
+          fail-on: ERR
+
   release:
     name: Release
     if: startsWith(github.event.ref, 'refs/tags/v')
@@ -280,6 +293,7 @@ jobs:
       - lint
       - reuse
       - generate
+      - openapi-check-breaking
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
### Description

Automatically detect breaking changes in the API by running oasdiff in CI. The build will fail if any breaking changes are detected, ensuring API stability.

Reference: https://github.com/Tufin/oasdiff

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
