### PR TITLE
fix: baseMWs are not called

### DIFF
--- a/cmd/wfx/cmd/root/server_collection.go
+++ b/cmd/wfx/cmd/root/server_collection.go
@@ -287,7 +287,7 @@ func (sc *ServerCollection) Stop() {
 
 func createServer(cfg *config.AppConfig, ssi genApi.StrictServerInterface, baseMWs []genApi.MiddlewareFunc, pluginMWs []*plugin.Middleware) (*http.Server, error) {
 	combinedMWs := make([]genApi.MiddlewareFunc, 0, len(baseMWs)+len(pluginMWs))
-	_ = copy(combinedMWs, baseMWs)
+	combinedMWs = append(combinedMWs, baseMWs...)
 	for _, mw := range pluginMWs {
 		combinedMWs = append(combinedMWs, mw.Middleware())
 	}


### PR DESCRIPTION
### Description

The base middlewares (baseMWs) were not being invoked due to an incorrect use of the copy() function, which only copies elements up to the length of the destination slice. Since the destination slice was initialized with zero length, no elements were copied. This has been fixed by appending each middleware function individually to the combinedMWs slice.

Fixes: f9825d67c1652e2b36cab526d7aa7d9bcd85ce85 (not yet released)

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
