### PR TITLE
feat: change access log level to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wfxctl health` validates the certificate chain when using TLS
 - Forbbiden requests (e.g. job creation via southbound API) now return HTTP status code 403 instead of 405
 - System certificates will be loaded automatically for TLS communication
+- Access log level was changed from `INFO` to `DEBUG` to avoid logging a message for every poll by each client.
+  To restore the old behavior, start wfx with `--log-level=DEBUG` (note that this will enable additional log messages
+  though).
 
 ## [0.3.3] - 2024-12-23
 

--- a/middleware/logging/log.go
+++ b/middleware/logging/log.go
@@ -73,7 +73,7 @@ func NewLoggingMiddleware() func(http.Handler) http.Handler {
 				}
 			}
 
-			contextLogger.Info().
+			contextLogger.Debug().
 				TimeDiff("duration", time.Now(), start).
 				Int("code", writer.statusCode).
 				Msg("Finished request")


### PR DESCRIPTION
### Description

Access log level was changed from INFO to DEBUG to avoid logging a message for every poll by each client.
To restore the old behavior, start wfx with --log-level=DEBUG (note that this will enable additional log messages though).

Closes #292 

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
