### PR TITLE
fix: do not close SSE connection due to inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `wfx`: implemented sort functionality for `/workflows` endpoint
+- `wfx`: fixed an issue where job event connections were prematurely closed due to inactivity
 
 ### Changed
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -157,8 +157,8 @@ See `wfxctl job events --help` for other filter parameters, e.g. workflow names.
    there are multiple wfx instances, a consolidated "global" event stream can only be assembled by subscribing to all
    wfx instances (and aggregating the events).
 4. **Browser Connection Limits for SSE**: Web browsers typically restrict the number of SSE connections to six per
-   domain. To overcome this limitation, HTTP/2 can be used, allowing up to 100 connections by default, or [filter
-   parameters](#filter-parameters) can be utilized to efficiently manage the connections.
+   domain.
+5. **HTTP/2**: Not supported currently. The HTTP protocol is limited to HTTP/1.1.
 
 ### Response Filters
 

--- a/middleware/sse/recorder.go
+++ b/middleware/sse/recorder.go
@@ -1,0 +1,52 @@
+//go:build testing
+
+package sse
+
+/*
+ * SPDX-FileCopyrightText: 2025 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+)
+
+// MockResponseRecorder extends httptest.ResponseRecorder and implements http.Hijacker.
+type MockResponseRecorder struct {
+	*httptest.ResponseRecorder
+	hijackedConn net.Conn
+	ChResponse   chan string
+}
+
+// Ensure MockResponseRecorder implements http.Hijacker.
+var _ http.Hijacker = &MockResponseRecorder{}
+
+// NewMockResponseRecorder creates a new MockResponseRecorder.
+func NewMockResponseRecorder() *MockResponseRecorder {
+	return &MockResponseRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		ChResponse:       make(chan string),
+	}
+}
+
+// Hijack implements the http.Hijacker interface.
+func (c *MockResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if c.hijackedConn == nil {
+		// Create a dummy connection for testing purposes.
+		var r net.Conn
+		c.hijackedConn, r = net.Pipe()
+		go func() {
+			response, _ := io.ReadAll(r)
+			c.ChResponse <- string(response)
+		}()
+	}
+	rw := bufio.NewReadWriter(bufio.NewReader(c.hijackedConn), bufio.NewWriter(c.hijackedConn))
+	return c.hijackedConn, rw, nil
+}


### PR DESCRIPTION
### Description

Job event connections were prematurely closed due to inactivity.

Fixes: 976875fab380ef85ece8c3b835a3ae4e891f9e70

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
