### PR TITLE
feat: Start wfx service on package installation on systems using syst…

### DIFF
--- a/.ci/goreleaser/postinstall.sh
+++ b/.ci/goreleaser/postinstall.sh
@@ -11,3 +11,8 @@ fi
 
 mkdir -p /var/lib/wfx
 chown -R wfx:wfx /var/lib/wfx
+
+if command -v systemctl &> /dev/null; then
+    systemctl enable wfx.service
+    systemctl start wfx.service
+fi

--- a/.ci/goreleaser/preremove.sh
+++ b/.ci/goreleaser/preremove.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2025 Siemens AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if command -v systemctl &> /dev/null; then
+    systemctl disable wfx.service
+    systemctl stop wfx.service
+fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -147,6 +147,7 @@ nfpms:
     priority: extra
     scripts:
       postinstall: .ci/goreleaser/postinstall.sh
+      preremove: .ci/goreleaser/preremove.sh
       postremove: .ci/goreleaser/postremove.sh
     contents:
       # it's the same content for all architectures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Start and enable wfx service on installation and stop and disable it on removal
 - Migrated from Swagger to OpenAPI v3
 - The previous Swagger (OpenAPI v2) specification is still available at `/api/wfx/v1/swagger.json` to _ensure compatibility_ with older clients (e.g., SWUpdate <= 2024.12). This endpoint will be removed in a future release.
 - The top-level `/swagger.json` is no longer served, as no known clients make use of it.


### PR DESCRIPTION
…emd.

### Description

For Debian packages it is common to start services included directly after installation.
Typically, this behavior is enforced by dh_* scripts added to the rules files.
(e.g.: https://manpages.debian.org/bookworm/debhelper/dh_systemd_enable.1.en.html )
I decided against using a rules file as this seems non idiomatic for nFPM.

#### Issues Addressed

I added systemd support to enable+start wfx on installation and disable+stop it on removal.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  if users expect wfx not to be started automatically.
- [ ] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
  Since I could not find a next branch, I raised this PR for main
- [X] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
       I did a local build of deb package and manual installation / removal using dpkg
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
