### PR TITLE
feat(docker): bind --mgmt-host to all interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `--mgmt-host` to `0.0.0.0` in the Docker image, allowing the management port (`--mgmt-port`) to be easily exposed and accessed from the host
+
 ## [0.4.1] - 2025-08-28
 
 This is a maintenance release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY wfx /usr/bin/wfx
 
 EXPOSE 8080 8081
 
-ENTRYPOINT ["wfx"]
+ENTRYPOINT ["wfx", "--mgmt-host=0.0.0.0"]


### PR DESCRIPTION
### Description

This change simplifies container usage. Previously, exposing the `--mgmt-port` required both `--publish` and manually setting `--mgmt-host=0.0.0.0` as a CLI argument to wfx.

Note: The `--mgmt-host` value can still be overridden by passing it as an argument to docker run; the last occurrence takes precedence.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
