### PR TITLE
chore(wfxctl): remove some noisy log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set `--mgmt-host` to `0.0.0.0` in the Docker image, allowing the management port (`--mgmt-port`) to be easily exposed and accessed from the host
+- `wfxctl`: removed debug log showing wfxctl version at startup (use `--version` if needed)
+- `wfxctl health`: suppress warning when endpoint is down, as health checks may run during expected failures (e.g., waiting for wfx to start)
 
 ## [0.4.1] - 2025-08-28
 

--- a/cmd/wfxctl/cmd/root.go
+++ b/cmd/wfxctl/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/siemens/wfx/cmd/wfx/cmd/config"
 	"github.com/siemens/wfx/cmd/wfxctl/cmd/health"
 	"github.com/siemens/wfx/cmd/wfxctl/cmd/job"
@@ -32,16 +31,9 @@ func NewCommand() *cobra.Command {
 
 Tip: Shell completion is available for Bash, Fish and Zsh. See wfxctl completion --help for more information.
 `,
-		Version:          metadata.Version,
+		Version:          fmt.Sprintf("%s (commit %s)", metadata.Version, metadata.Commit),
 		SilenceUsage:     true,
 		TraverseChildren: true,
-		PersistentPreRun: func(*cobra.Command, []string) {
-			log.Debug().
-				Str("version", metadata.Version).
-				Str("date", metadata.Date).
-				Str("commit", metadata.Commit).
-				Msg("wfxctl")
-		},
 	}
 	cmd.AddCommand(man.NewCommand())
 	cmd.AddCommand(job.NewCommand())


### PR DESCRIPTION
### Description

- Remove debug message containing wfxctl version on wfxctl startup (use --version if interested)
- Remove warning if an endpoint is down (after all, the health subcommand is often expected to fail, e.g. wfx not yet up and running)

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
