### PR TITLE
remove(basecmd): drop the --workflow-name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `--mgmt-host` to `0.0.0.0` in the Docker image, allowing the management port (`--mgmt-port`) to be easily exposed and accessed from the host
 - `wfxctl`: removed debug log showing wfxctl version at startup (use `--version` if needed)
 - `wfxctl health`: suppress warning when endpoint is down, as health checks may run during expected failures (e.g., waiting for wfx to start)
+- `wfxctl job events`: fixed usage of the `--workflow` flag to filter job events by workflow name. This flag was previously not considered.
 
 ## [0.4.1] - 2025-08-28
 

--- a/cmd/wfxctl/flags/basecmd.go
+++ b/cmd/wfxctl/flags/basecmd.go
@@ -67,7 +67,6 @@ const (
 	TLSCaFlag            = "tls-ca"
 	TagFlag              = "tag"
 	WorkflowFlag         = "workflow"
-	WorkflowNameFlag     = "workflow-name"
 	NameFlag             = "name"
 	AutoReconnectFlag    = "auto-reconnect"
 )
@@ -184,7 +183,7 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 		TLSPort:     k.Int(ClientTLSPortFlag),
 		Tags:        k.Strings(TagFlag),
 		Workflow:    k.String(WorkflowFlag),
-		Workflows:   k.Strings(WorkflowNameFlag),
+		Workflows:   k.Strings(WorkflowFlag),
 		Progress:    k.Int(ProgressFlag),
 		Message:     k.String(MessageFlag),
 		State:       k.String(StateFlag),


### PR DESCRIPTION
### Description

Removing the --workflow-name flag leads to more consistent usage when referring to workflows via arguments in CLI tools.

This also fixes the usage of the --workflow argument in the `wfxctl job events` command. Until now, passing the --workflow argument was not recognized correctly by the tool.

Steps to reproduce:
 
```bash
wfxctl job events --client-id="mtda-wfx-test-client" --workflow="wfx.workflow.device.reservation" --workflow="wfx.workflow.device.release"
```

```bash
# WFX server
Adding new subscriber for job events filterParams={"actions":null,"clientIDs":["mtda-wfx-test-client"],"jobIDs":[],"workflows":[]} reqID=c6861797-5322-4cba-8301-aa83f3c9b1ed subscriberID=4a8b7a28-0051-4d67-8d9b-afd10b0244ee tags=[]
```
#### Issues Addressed

No issue created. Should I create one and post logs to have this better documented?



#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
