### PR TITLE
docs(github): fix links in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@ Please select the relevant options:
 
 #### Checklist
 
-- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
+- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
 - [ ] My changes adhere to the established code style, patterns, and best practices.
 - [ ] I have added tests that demonstrate the effectiveness of my changes.
 - [ ] I have updated the documentation accordingly (if applicable).
-- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
+- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).


### PR DESCRIPTION
### Description

The pull request template refers to the CONTRIBUTING and CHANGELOG file by using ***..*** , this does not work in the Github UI (you can verify this by clicking the links below). I change it to an absolute path.

Though I'm not sure if you want to have hard links in the documentation. Feel free to close this if it doesn't match. I was just confused when clicking on the broken links in the previous PR.

#### Issues Addressed

n/a

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](../CHANGELOG.md) to document my changes (if applicable).
