### PR TITLE
feat(wfxctl): support JSON format in workflow create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- wfxctl: support JSON format in workflow create command
 - Log all SQL queries when `--log-level` is set to `trace`
 - wfx-loadtest: add `populate` sub-command to seed a database with sample data
 

--- a/cmd/wfxctl/cmd/workflow/create/create.go
+++ b/cmd/wfxctl/cmd/workflow/create/create.go
@@ -9,6 +9,7 @@ package create
  */
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -53,7 +54,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new workflow",
-		Long:  `Create a new workflow. The workflow must be in YAML format.`,
+		Long:  `Create a new workflow. The workflow must be in YAML or JSON format.`,
 		Example: fmt.Sprintf(`
 cat <<EOF | wfxctl workflow create -
 %s
@@ -62,7 +63,7 @@ EOF
 		TraverseChildren: true,
 		Args:             cobra.OnlyValidArgs,
 		ValidArgsFunction: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-			return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
+			return []string{"yaml", "yml", "json"}, cobra.ShellCompDirectiveFilterFileExt
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			baseCmd := flags.NewBaseCmd(cmd.Flags())
@@ -122,10 +123,15 @@ func readWorkflows(args []string, r io.Reader) ([]api.Workflow, error) {
 }
 
 func unmarshal(raw []byte) (*api.Workflow, error) {
-	// try YAML
 	var wf api.Workflow
-	err := yaml.Unmarshal(raw, &wf)
-	if err != nil {
+	// try JSON first
+	if json.Valid(raw) {
+		if err := json.Unmarshal(raw, &wf); err == nil {
+			return &wf, nil
+		}
+	}
+	// fall back to YAML
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
 		return nil, fault.Wrap(err)
 	}
 	return &wf, nil

--- a/cmd/wfxctl/cmd/workflow/create/create_test.go
+++ b/cmd/wfxctl/cmd/workflow/create/create_test.go
@@ -25,44 +25,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateWorkflow_YAML(t *testing.T) {
+func TestCreateWorkflow(t *testing.T) {
 	var body []byte
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ = io.ReadAll(r.Body)
-
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte("{}"))
+		b, _ := json.Marshal(dau.DirectWorkflow())
+		_, _ = w.Write(b)
 	}))
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	u, _ := url.Parse(ts.URL)
+
+	tests := []struct {
+		name     string
+		marshal  func() ([]byte, error)
+		expected func(input []byte) []byte
+	}{
+		{
+			name: "YAML",
+			marshal: func() ([]byte, error) {
+				return yaml.Marshal(dau.DirectWorkflow())
+			},
+			expected: func(input []byte) []byte {
+				var wf api.Workflow
+				_ = yaml.Unmarshal(input, &wf)
+				b, _ := json.Marshal(wf)
+				return b
+			},
+		},
+		{
+			name: "JSON",
+			marshal: func() ([]byte, error) {
+				return json.Marshal(dau.DirectWorkflow())
+			},
+			expected: func(input []byte) []byte {
+				var wf api.Workflow
+				_ = json.Unmarshal(input, &wf)
+				b, _ := json.Marshal(wf)
+				return b
+			},
+		},
+	}
+
 	t.Setenv("WFX_MGMT_HOST", u.Hostname())
 	t.Setenv("WFX_MGMT_PORT", u.Port())
 
-	f, err := os.CreateTemp("", "wfx-")
-	require.NoError(t, err)
-	defer func() {
-		_ = f.Close()
-		_ = os.Remove(f.Name())
-	}()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "wfx-")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = f.Close()
+				_ = os.Remove(f.Name())
+			})
 
-	b, err := yaml.Marshal(dau.DirectWorkflow())
-	require.NoError(t, err)
-	workflowYaml := string(b)
+			b, err := tc.marshal()
+			require.NoError(t, err)
 
-	_, _ = f.WriteString(workflowYaml)
-	cmd := NewCommand()
-	cmd.SetArgs([]string{f.Name()})
+			_, _ = f.Write(b)
+			cmd := NewCommand()
+			cmd.SetArgs([]string{f.Name()})
 
-	err = cmd.Execute()
-	require.NoError(t, err)
+			err = cmd.Execute()
+			require.NoError(t, err)
 
-	var wf api.Workflow
-	_ = yaml.Unmarshal([]byte(workflowYaml), &wf)
-	b, _ = json.Marshal(wf)
-	assert.JSONEq(t, string(b), string(body))
+			assert.JSONEq(t, string(tc.expected(b)), string(body))
+		})
+	}
 }
 
 func TestReadWorkflows_None(t *testing.T) {

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -251,6 +251,13 @@ wfxctl workflow create --filter=.transitions wfx.workflow.kanban.yml
 ```
 
 loads the Kanban workflow into wfx making it available to create jobs driven by it.
+
+The command accepts both YAML and JSON formats, so you can also use a JSON file directly (e.g. as returned by the wfx API):
+
+```sh
+wfxctl workflow create wfx.workflow.kanban.json
+```
+
 Note that the the command's output was made less verbose by using a `--filter` to only show the transitions.
 
 Henceforth, a job is identified with a "Task" and a state is identified with a "Lane" in Kanban board parlance.

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,8 @@ mkShell {
     just
     git
     go
+    gopls
+    reftools
     flatbuffers
     openssl
     zstd


### PR DESCRIPTION
### Description

The REST endpoint for workflows returns a JSON response, so it makes sense for wfxctl to accept workflows in JSON too, improving composability (e.g. piping API responses back into wfxctl).

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
