### PR TITLE
docs(api): document job ID character constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Distro-compliant package naming
 - Querying jobs by tags is about 3x faster (e.g. ~1s instead of ~3s for 1 million jobs)
+- Job IDs are now explicitly documented as restricted to characters in the set [A-Za-z0-9_.-]
 
 ### Fixed
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -79,6 +79,8 @@ accommodate a variety of use cases and workflows that are tailored to specific n
 For example, firmware and container image updates may have different requirements and constraints that require separate
 workflows to address them.
 
+**Note**: A **Job ID** consists of characters matching the pattern `^[A-Za-z0-9_.-]+$`, i.e. alphanumeric characters, underscores, dots, and hyphens.
+
 ### Creating Jobs
 
 A new job can be created by sending a `JobRequest` object (see [wfx OpenAPI Specification](../spec/wfx.openapi.yml)) to wfx's [northbound REST API](operations.md#API).

--- a/spec/wfx.openapi.yml
+++ b/spec/wfx.openapi.yml
@@ -1286,10 +1286,11 @@ components:
       name: id
       x-go-name: paramJobID
       in: path
-      description: Job ID
+      description: Job ID (must consist of characters in the set [A-Za-z0-9_.-])
       required: true
       schema:
         type: string
+        pattern: "^[A-Za-z0-9_.-]+$"
     tag:
       name: tag
       x-go-name: paramTag


### PR DESCRIPTION
### Description

Valid job IDs must consist of characters in the set `[A-Za-z0-9_.-]`. This is not a breaking change but explicitly documents existing behavior by adding a pattern constraint to the OpenAPI spec.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
