### PR TITLE
fix: prevent invalid job transitions on concurrent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI: collapse pagination bar for large (> 50) page counts
 - Drop redundant JSON field from journald log records, roughly halving per-record journal storage
 - Prevent invalid (TOCTOU) job updates when concurrent callers attempt to modify the same job
+- Avoid spurious unique-constraint failures when concurrent callers add the same new tag name to different jobs
 
 ## [0.5.0] - 2026-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `Subscriber.ch` channels are not double-closed when stopping the server
 - UI: collapse pagination bar for large (> 50) page counts
 - Drop redundant JSON field from journald log records, roughly halving per-record journal storage
+- Prevent invalid (TOCTOU) job updates when concurrent callers attempt to modify the same job
 
 ## [0.5.0] - 2026-03-09
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -41,3 +41,9 @@ var WorkflowInvalid = api.Error{
 	Logref:  "18f57adc70dd79c7fb4f1246be8a6e04",
 	Message: "Workflow validation failed",
 }
+
+var JobModifiedConcurrently = api.Error{
+	Code:    "wfx.jobModifiedConcurrently",
+	Logref:  "dc00b05825b44934afeb9454f42a6440",
+	Message: "Job was modified concurrently",
+}

--- a/api/wfx.go
+++ b/api/wfx.go
@@ -22,6 +22,7 @@ import (
 	"github.com/siemens/wfx/cmd/wfx/cmd/config"
 	"github.com/siemens/wfx/cmd/wfx/metadata"
 	"github.com/siemens/wfx/generated/api"
+	"github.com/siemens/wfx/internal/errkind"
 	"github.com/siemens/wfx/internal/handler/job"
 	"github.com/siemens/wfx/internal/handler/job/definition"
 	"github.com/siemens/wfx/internal/handler/job/events"
@@ -260,12 +261,20 @@ func (server WfxServer) PutJobsIdDefinition(ctx context.Context, request api.Put
 	}
 	definition, err := definition.Update(ctx, server.storage, request.Id, def)
 	if err != nil {
-		if ftag.Get(err) == ftag.NotFound {
+		switch ftag.Get(err) {
+		case ftag.NotFound:
 			return api.PutJobsIdDefinition404JSONResponse(api.ErrorResponse{
 				Errors: &[]api.Error{JobNotFound},
 			}), nil
+		case errkind.TOCTOU:
+			err2 := JobModifiedConcurrently
+			err2.Message = err.Error()
+			return api.PutJobsIdDefinition400JSONResponse(api.ErrorResponse{
+				Errors: &[]api.Error{err2},
+			}), nil
+		default:
+			return nil, fault.Wrap(err)
 		}
-		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
 		return NewJQFilter(*request.Params.XResponseFilter, definition), nil
@@ -311,6 +320,12 @@ func (server WfxServer) PutJobsIdStatus(ctx context.Context, request api.PutJobs
 			return api.PutJobsIdStatus400JSONResponse(api.ErrorResponse{
 				Errors: &[]api.Error{err2},
 			}), nil
+		case errkind.TOCTOU:
+			err2 := JobModifiedConcurrently
+			err2.Message = err.Error()
+			return api.PutJobsIdStatus400JSONResponse(api.ErrorResponse{
+				Errors: &[]api.Error{err2},
+			}), nil
 		default:
 			return nil, fault.Wrap(err)
 		}
@@ -331,12 +346,20 @@ func (server WfxServer) DeleteJobsIdTags(ctx context.Context, request api.Delete
 	tagsToDelete = *request.Body
 	tags, err := tags.Delete(ctx, server.storage, request.Id, tagsToDelete)
 	if err != nil {
-		if ftag.Get(err) == ftag.NotFound {
+		switch ftag.Get(err) {
+		case ftag.NotFound:
 			return api.DeleteJobsIdTags404JSONResponse(api.ErrorResponse{
 				Errors: &[]api.Error{JobNotFound},
 			}), nil
+		case errkind.TOCTOU:
+			err2 := JobModifiedConcurrently
+			err2.Message = err.Error()
+			return api.DeleteJobsIdTags400JSONResponse(api.ErrorResponse{
+				Errors: &[]api.Error{err2},
+			}), nil
+		default:
+			return nil, fault.Wrap(err)
 		}
-		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
 		return NewJQFilter(*request.Params.XResponseFilter, tags), nil
@@ -377,12 +400,20 @@ func (server WfxServer) PostJobsIdTags(ctx context.Context, request api.PostJobs
 	}
 	tags, err := tags.Add(ctx, server.storage, request.Id, body)
 	if err != nil {
-		if ftag.Get(err) == ftag.NotFound {
+		switch ftag.Get(err) {
+		case ftag.NotFound:
 			return api.PostJobsIdTags404JSONResponse(api.ErrorResponse{
 				Errors: &[]api.Error{JobNotFound},
 			}), nil
+		case errkind.TOCTOU:
+			err2 := JobModifiedConcurrently
+			err2.Message = err.Error()
+			return api.PostJobsIdTags400JSONResponse(api.ErrorResponse{
+				Errors: &[]api.Error{err2},
+			}), nil
+		default:
+			return nil, fault.Wrap(err)
 		}
-		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
 		return NewJQFilter(*request.Params.XResponseFilter, tags), nil

--- a/api/wfx_test.go
+++ b/api/wfx_test.go
@@ -10,10 +10,15 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/alexliesenfeld/health"
 	"github.com/siemens/wfx/generated/api"
+	"github.com/siemens/wfx/internal/persistence/entgo"
 	"github.com/siemens/wfx/persistence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,4 +57,83 @@ func TestGetJobsEvents(t *testing.T) {
 	response, err := wfx.GetJobsEvents(ctx, request)
 	require.NoError(t, err)
 	assert.NotNil(t, response)
+}
+
+func TestPutJobsIdStatusConcurrent(t *testing.T) {
+	db := newSQLiteStorage(t)
+	wfx := NewWfxServer(db)
+
+	const workers = 10
+
+	// Build a custom workflow: START -> T0..T(workers-1), all triggered by CLIENT.
+	// There are no transitions out of any T_i, so only one goroutine can succeed.
+	wfDef := &api.Workflow{Name: "concurrent.test"}
+	wfDef.States = append(wfDef.States, api.State{Name: "START"})
+	for i := range workers {
+		target := fmt.Sprintf("T%d", i)
+		wfDef.States = append(wfDef.States, api.State{Name: target})
+		wfDef.Transitions = append(wfDef.Transitions, api.Transition{
+			From:     "START",
+			To:       target,
+			Eligible: api.CLIENT,
+		})
+	}
+	wf, err := db.CreateWorkflow(t.Context(), wfDef)
+	require.NoError(t, err)
+
+	job, err := db.CreateJob(t.Context(), &api.Job{
+		ClientID: "foo",
+		Workflow: wf,
+		Status:   &api.JobStatus{State: "START"},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var successes int32
+	var rejected int32
+	start := make(chan struct{})
+
+	ctx := context.WithValue(t.Context(), EligibleKey, api.CLIENT)
+
+	for i := range workers {
+		body := api.PutJobsIdStatusJSONRequestBody{State: fmt.Sprintf("T%d", i)}
+		req := api.PutJobsIdStatusRequestObject{
+			Id:   job.ID,
+			Body: &body,
+		}
+		wg.Go(func() {
+			<-start
+			resp, err := wfx.PutJobsIdStatus(ctx, req)
+			require.NoError(t, err)
+			switch resp.(type) {
+			case api.PutJobsIdStatus200JSONResponse:
+				atomic.AddInt32(&successes, 1)
+			case api.PutJobsIdStatus400JSONResponse:
+				atomic.AddInt32(&rejected, 1)
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&successes),
+		"exactly one concurrent update may succeed in moving the state forward")
+	assert.Equal(t, int32(workers-1), atomic.LoadInt32(&rejected),
+		"all other updates must be rejected")
+}
+
+func newSQLiteStorage(t *testing.T) persistence.Storage {
+	db := &entgo.SQLite{}
+	// File-backed sqlite with WAL journaling and a generous busy timeout so
+	// concurrent writers serialize cleanly instead of returning SQLITE_BUSY.
+	// A pure in-memory DSN combined with cache=shared still exhibits
+	// "database table is locked" under contention because mattn/go-sqlite3
+	// opens multiple connections; the WAL journal mode plus busy_timeout
+	// avoids that.
+	f := filepath.Join(t.TempDir(), "wfx.db")
+	dsn := "file:" + f + "?_fk=1&_journal=WAL&_busy_timeout=5000"
+	require.NoError(t, db.Initialize(dsn))
+	t.Cleanup(db.Shutdown)
+	return db
 }

--- a/internal/errkind/kind.go
+++ b/internal/errkind/kind.go
@@ -1,0 +1,10 @@
+package errkind
+
+import "github.com/Southclaws/fault/ftag"
+
+// TOCTOU is an error kind indicating a Time-Of-Check to Time-Of-Use race.
+// For example, an entity (e.g. a job) was concurrently modified between the moment its state was read and the moment an
+// update was attempted.
+// It will typically result in a 400 response, so clients can retry the operation with fresh data instead of receiving
+// an opaque server error.
+const TOCTOU = ftag.Kind("TOCTOU")

--- a/internal/handler/job/status/update.go
+++ b/internal/handler/job/status/update.go
@@ -62,17 +62,21 @@ func Update(ctx context.Context, storage persistence.Storage, jobID string, newS
 		return nil, fault.Wrap(fmt.Errorf("transition from '%s' to '%s' is not allowed for actor '%s'", from, to, actor), ftag.With(ftag.InvalidArgument))
 	}
 
-	// transition is allowed, now apply wfx transitions
+	// transition is allowed, now apply wfx transitions.
+	// Make a local copy so we do not mutate the caller-provided newStatus,
+	// which may be shared across goroutines (e.g. concurrent requests).
 	newTo := workflow.FollowImmediateTransitions(job.Workflow, to)
-	if newTo != to {
+	var updatedStatus api.JobStatus
+	if newTo == to {
+		updatedStatus = *newStatus
+	} else {
 		contextLogger.Debug().Str("to", to).Str("newTo", newTo).Msgf("Resetting state from %q to %q after following immediate transitions", to, newTo)
-		newStatus = &api.JobStatus{}
 	}
-	newStatus.State = newTo
+	updatedStatus.State = newTo
 	// override any definitionHash provided by client
-	newStatus.DefinitionHash = job.Status.DefinitionHash
+	updatedStatus.DefinitionHash = job.Status.DefinitionHash
 
-	result, err := storage.UpdateJob(ctx, job, persistence.JobUpdate{Status: newStatus})
+	result, err := storage.UpdateJob(ctx, job, persistence.JobUpdate{Status: &updatedStatus})
 	if err != nil {
 		contextLogger.Err(err).Msg("Failed to persist job update")
 		return nil, fault.Wrap(err)
@@ -94,7 +98,7 @@ func Update(ctx context.Context, storage persistence.Storage, jobID string, newS
 
 	contextLogger.Info().
 		Str("from", from).
-		Str("to", newStatus.State).
+		Str("to", updatedStatus.State).
 		Msg("Updated job status")
 	return result.Status, nil
 }

--- a/internal/persistence/entgo/job_update.go
+++ b/internal/persistence/entgo/job_update.go
@@ -10,13 +10,17 @@ package entgo
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/Southclaws/fault"
+	"github.com/Southclaws/fault/ftag"
 	"github.com/siemens/wfx/generated/api"
 	"github.com/siemens/wfx/generated/ent"
+	entjob "github.com/siemens/wfx/generated/ent/job"
 	"github.com/siemens/wfx/generated/ent/tag"
+	"github.com/siemens/wfx/internal/errkind"
 	"github.com/siemens/wfx/internal/workflow"
 	"github.com/siemens/wfx/middleware/logging"
 	"github.com/siemens/wfx/persistence"
@@ -57,9 +61,21 @@ func (db Database) UpdateJob(ctx context.Context, job *api.Job, request persiste
 func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persistence.JobUpdate) (*api.Job, error) {
 	log := logging.LoggerFromCtx(ctx).With().Str("id", job.ID).Logger()
 
-	updater := tx.Job.UpdateOneID(job.ID)
-
 	oldMtime := time.Time(*job.Mtime)
+
+	// Optimistic concurrency control: only update if mtime in the database still matches the mtime of the job we read
+	// earlier. This prevents time-of-check-to-time-of-use races where two callers concurrently transition the same job
+	// (for example, both moving from state A, but to different target states); without this guard, both would succeed
+	// and the second would silently overwrite the first.
+	//
+	// Note: simply wrapping the read + validate + write in a single transaction is NOT sufficient to fix this race. At
+	// the default isolation level (READ COMMITTED on PostgreSQL, REPEATABLE READ on MySQL InnoDB), two transactions can
+	// both SELECT the same row and then both UPDATE it - the second waits for the first to commit and then clobbers its
+	// result. SQLite serializes writers globally, but likewise just runs the second writer after the first. Preventing
+	// the lost update therefore requires either pessimistic row locking (SELECT ... FOR UPDATE, not portable to SQLite
+	// and forcing a transactional Storage API) or this optimistic mtime check, which is portable across all supported
+	// backends and adds no contention.
+	updater := tx.Job.UpdateOneID(job.ID).Where(entjob.MtimeEQ(oldMtime))
 
 	if request.Status != nil {
 		updater.SetStatus(*request.Status)
@@ -144,6 +160,16 @@ func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persiste
 
 	entity, err := updater.Save(ctx)
 	if err != nil {
+		// If no row matched, distinguish between "job no longer exists" and
+		// "job was concurrently modified" so callers (and humans reading logs)
+		// can tell why their update was rejected.
+		if ent.IsNotFound(err) {
+			exists, existsErr := tx.Job.Query().Where(entjob.IDEQ(job.ID)).Exist(ctx)
+			if existsErr == nil && exists {
+				log.Warn().Time("expectedMtime", oldMtime).Msg("Concurrent update detected; aborting")
+				return nil, fault.Wrap(fmt.Errorf("status of job %s was concurrently modified", job.ID), ftag.With(errkind.TOCTOU))
+			}
+		}
 		return nil, fault.Wrap(err)
 	}
 

--- a/internal/persistence/entgo/job_update.go
+++ b/internal/persistence/entgo/job_update.go
@@ -30,13 +30,25 @@ import (
 func (db Database) UpdateJob(ctx context.Context, job *api.Job, request persistence.JobUpdate) (*api.Job, error) {
 	log := logging.LoggerFromCtx(ctx).With().Str("id", job.ID).Logger()
 
+	// Resolve (and if necessary create) any new tag rows BEFORE starting the job-update transaction. Tag rows are
+	// global, idempotent, and protected by a UNIQUE(name) index. Two concurrent UpdateJob calls (on different jobs)
+	// that both add the same brand-new tag would otherwise observe the row as missing, both attempt to insert, and one
+	// would lose with a constraint violation that aborts the entire enclosing transaction (Postgres aborts the
+	// transaction on any error; MySQL/SQLite just fail the statement). Doing it outside the main transaction lets us
+	// swallow the benign duplicate-key error and re-resolve, without poisoning the job update.
+	tagsByName, err := db.ensureTagsExist(ctx, request.AddTags)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to ensure tags exist")
+		return nil, fault.Wrap(err)
+	}
+
 	tx, err := db.client.Tx(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to start transaction")
 		return nil, fault.Wrap(err)
 	}
 
-	updatedJob, err := doUpdateJob(ctx, tx, job, request)
+	updatedJob, err := doUpdateJob(ctx, tx, job, request, tagsByName)
 	if err != nil {
 		log.Error().Err(err).Msg("Rolling back transaction")
 		if txErr := tx.Rollback(); txErr != nil {
@@ -58,7 +70,7 @@ func (db Database) UpdateJob(ctx context.Context, job *api.Job, request persiste
 	return updatedJob, nil
 }
 
-func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persistence.JobUpdate) (*api.Job, error) {
+func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persistence.JobUpdate, tagsByName map[string]*ent.Tag) (*api.Job, error) {
 	log := logging.LoggerFromCtx(ctx).With().Str("id", job.ID).Logger()
 
 	oldMtime := time.Time(*job.Mtime)
@@ -96,48 +108,18 @@ func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persiste
 	}
 	{ // deal with tags
 		if request.AddTags != nil && len(*request.AddTags) > 0 {
-			// tags which we have to add to the job
-			tagsToAdd := make([]string, 0, len(*request.AddTags))
+			// Tag rows were already resolved/created outside this transaction (see UpdateJob).
+			// Attach the ones the job does not have yet.
 			for _, name := range *request.AddTags {
-				if _, found := allTags[name]; !found {
-					tagsToAdd = append(tagsToAdd, name)
+				if _, found := allTags[name]; found {
+					continue
 				}
-			}
-
-			// query already existing tags from the database
-			var existingTags map[string]*ent.Tag
-			{
-				existing, err := tx.Tag.Query().Where(tag.NameIn(tagsToAdd...)).All(ctx)
-				if err != nil {
-					return nil, fault.Wrap(err)
+				t, ok := tagsByName[name]
+				if !ok {
+					// Should not happen: ensureTagsExist guarantees coverage.
+					return nil, fault.Wrap(fmt.Errorf("tag %q not pre-resolved", name))
 				}
-				existingTags = make(map[string]*ent.Tag, len(existing))
-				for _, t := range existing {
-					existingTags[t.Name] = t
-				}
-			}
-
-			// tags which do not exist yet
-			tagsToCreate := make([]*ent.TagCreate, 0)
-			for _, name := range tagsToAdd {
-				if t, found := existingTags[name]; found {
-					// otherwise we lose them
-					updater.AddTags(t)
-				} else {
-					// add it to our bulk creation query
-					tagsToCreate = append(tagsToCreate, tx.Tag.Create().SetName(name))
-				}
-			}
-
-			if len(tagsToCreate) > 0 {
-				// create tags in db
-				newTags, err := tx.Tag.CreateBulk(tagsToCreate...).Save(ctx)
-				if err != nil {
-					log.Error().Err(err).Msg("Failed to create new tags")
-					return nil, fault.Wrap(err)
-				}
-				// add them to our update query
-				updater.AddTags(newTags...)
+				updater.AddTags(t)
 			}
 
 			// union set
@@ -201,4 +183,84 @@ func doUpdateJob(ctx context.Context, tx *ent.Tx, job *api.Job, request persiste
 	updatedJob.Tags = &tags
 
 	return &updatedJob, nil
+}
+
+// ensureTagsExist resolves the given tag names to ent.Tag rows, creating any
+// missing rows. It tolerates concurrent creators: if another transaction
+// inserts the same name between our query and our insert, the resulting
+// unique-constraint violation is swallowed and the row is re-fetched. The
+// returned map is keyed by tag name and contains exactly the requested tags
+// (empty if names was empty / nil).
+func (db Database) ensureTagsExist(ctx context.Context, names *[]string) (map[string]*ent.Tag, error) {
+	if names == nil || len(*names) == 0 {
+		return map[string]*ent.Tag{}, nil
+	}
+
+	// Deduplicate.
+	wanted := make(map[string]struct{}, len(*names))
+	for _, n := range *names {
+		wanted[n] = struct{}{}
+	}
+	wantedNames := make([]string, 0, len(wanted))
+	for n := range wanted {
+		wantedNames = append(wantedNames, n)
+	}
+
+	// maxAttempts bounds the query/create race-recovery loop. Each iteration re-queries existing tags and tries to
+	// create whatever is still missing; a concurrent writer can only cause us to lose the race on a given name once
+	// (after that the row exists and the next query picks it up). 3 is an arbitrary small ceiling that tolerates
+	// a burst of concurrent creators while still guaranteeing forward progress.
+	const maxAttempts = 3
+	result := make(map[string]*ent.Tag, len(wanted))
+
+	for range maxAttempts {
+		existing, err := db.client.Tag.Query().Where(tag.NameIn(wantedNames...)).All(ctx)
+		if err != nil {
+			return nil, fault.Wrap(err)
+		}
+		for _, t := range existing {
+			result[t.Name] = t
+		}
+
+		missing := make([]string, 0)
+		for n := range wanted {
+			if _, ok := result[n]; !ok {
+				missing = append(missing, n)
+			}
+		}
+		if len(missing) == 0 {
+			return result, nil
+		}
+
+		// create each missing tag in its own statement so a duplicate from a concurrent writer doesn't poison the
+		// others
+		for _, n := range missing {
+			t, err := db.client.Tag.Create().SetName(n).Save(ctx)
+			if err == nil {
+				result[n] = t
+				continue
+			}
+			if ent.IsConstraintError(err) {
+				// Lost the race - someone else just inserted this name. Fall
+				// through to the next loop iteration which will re-query.
+				continue
+			}
+			return nil, fault.Wrap(err)
+		}
+	}
+
+	// re-query so we pick up any rows that were inserted by concurrent writers in the last iteration
+	final, err := db.client.Tag.Query().Where(tag.NameIn(wantedNames...)).All(ctx)
+	if err != nil {
+		return nil, fault.Wrap(err)
+	}
+	for _, t := range final {
+		result[t.Name] = t
+	}
+	for n := range wanted {
+		if _, ok := result[n]; !ok {
+			return nil, fault.Wrap(fmt.Errorf("failed to ensure tag %q exists after %d attempts", n, maxAttempts))
+		}
+	}
+	return result, nil
 }

--- a/internal/persistence/tests/all.go
+++ b/internal/persistence/tests/all.go
@@ -25,9 +25,10 @@ var AllTests = []PersistenceTest{
 	TestJobsPagination,
 	TestQueryJobsFilter,
 	TestQueryWorkflows,
+	TestQueryWorkflowsSort,
 	TestUpdateJobDefinition,
 	TestUpdateJobStatus,
 	TestUpdateJobStatusNonExisting,
+	TestUpdateJobStatusStaleView,
 	TestWorkflowsPagination,
-	TestQueryWorkflowsSort,
 }

--- a/internal/persistence/tests/all.go
+++ b/internal/persistence/tests/all.go
@@ -18,6 +18,7 @@ var AllTests = []PersistenceTest{
 	TestGetJobWithHistory,
 	TestGetJobsSorted,
 	TestJobAddTags,
+	TestJobAddTagsConcurrent,
 	TestJobAddTagsOverlap,
 	TestJobDeleteTags,
 	TestJobDeleteTagsNonExisting,

--- a/internal/persistence/tests/job_update_status.go
+++ b/internal/persistence/tests/job_update_status.go
@@ -11,10 +11,11 @@ package tests
  */
 
 import (
-	"context"
 	"testing"
 
+	"github.com/Southclaws/fault/ftag"
 	"github.com/siemens/wfx/generated/api"
+	"github.com/siemens/wfx/internal/errkind"
 	"github.com/siemens/wfx/persistence"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,16 +26,16 @@ var defaultClientID = "foo"
 func TestUpdateJobStatus(t *testing.T, db persistence.Storage) {
 	tmp := newValidJob(defaultClientID)
 
-	_, err := db.CreateWorkflow(context.Background(), tmp.Workflow)
+	_, err := db.CreateWorkflow(t.Context(), tmp.Workflow)
 	require.NoError(t, err)
 
-	job, err := db.CreateJob(context.Background(), tmp)
+	job, err := db.CreateJob(t.Context(), tmp)
 	require.NoError(t, err)
 	mtime := job.Mtime
 
 	message := "Some arbitrary message"
 	update := api.JobStatus{Message: message, State: "ACTIVATING"}
-	updatedJob, err := db.UpdateJob(context.Background(), job, persistence.JobUpdate{Status: &update})
+	updatedJob, err := db.UpdateJob(t.Context(), job, persistence.JobUpdate{Status: &update})
 	assert.NoError(t, err)
 	assert.Greater(t, *updatedJob.Mtime, *mtime)
 	assert.Equal(t, "ACTIVATING", updatedJob.Status.State)
@@ -42,7 +43,7 @@ func TestUpdateJobStatus(t *testing.T, db persistence.Storage) {
 	assert.Nil(t, updatedJob.History)
 
 	{ // now fetch history and check our old state is there
-		job, err := db.GetJob(context.Background(), job.ID, persistence.FetchParams{History: true})
+		job, err := db.GetJob(t.Context(), job.ID, persistence.FetchParams{History: true})
 		history := *job.History
 		require.NoError(t, err)
 		assert.Len(t, history, 1)
@@ -53,9 +54,48 @@ func TestUpdateJobStatus(t *testing.T, db persistence.Storage) {
 func TestUpdateJobStatusNonExisting(t *testing.T, db persistence.Storage) {
 	job := newValidJob(defaultClientID)
 	message := "message"
-	updatedJob, err := db.UpdateJob(context.Background(), job,
+	updatedJob, err := db.UpdateJob(t.Context(), job,
 		persistence.JobUpdate{Status: &api.JobStatus{Message: message, State: "ACTIVATING"}},
 	)
 	assert.Error(t, err)
 	assert.Nil(t, updatedJob)
+}
+
+func TestUpdateJobStatusStaleView(t *testing.T, db persistence.Storage) {
+	tmp := newValidJob(defaultClientID)
+	_, err := db.CreateWorkflow(t.Context(), tmp.Workflow)
+	require.NoError(t, err)
+
+	job, err := db.CreateJob(t.Context(), tmp)
+	require.NoError(t, err)
+
+	// staleJob captures the state right after creation; we will use it for
+	// the second update, which should fail.
+	staleJob, err := db.GetJob(t.Context(), job.ID, persistence.FetchParams{})
+	require.NoError(t, err)
+
+	// First update succeeds and bumps mtime.
+	freshJob, err := db.GetJob(t.Context(), job.ID, persistence.FetchParams{})
+	require.NoError(t, err)
+	winner, err := db.UpdateJob(t.Context(), freshJob,
+		persistence.JobUpdate{Status: &api.JobStatus{State: "INSTALLING"}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "INSTALLING", winner.Status.State)
+	require.Greater(t, *winner.Mtime, *staleJob.Mtime)
+
+	// Second update uses the stale view; it must be rejected.
+	loser, err := db.UpdateJob(t.Context(), staleJob,
+		persistence.JobUpdate{Status: &api.JobStatus{State: "ACTIVATING"}},
+	)
+	assert.Error(t, err, "stale update must not silently succeed")
+	assert.Nil(t, loser)
+	assert.Equal(t, errkind.TOCTOU, ftag.Get(err),
+		"stale update should be flagged as a concurrent-modification conflict")
+
+	// The job in the database must reflect only the winner's update.
+	finalJob, err := db.GetJob(t.Context(), job.ID, persistence.FetchParams{})
+	require.NoError(t, err)
+	assert.Equal(t, "INSTALLING", finalJob.Status.State,
+		"loser update must not have overwritten the winner")
 }

--- a/internal/persistence/tests/job_update_tag.go
+++ b/internal/persistence/tests/job_update_tag.go
@@ -12,7 +12,9 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/siemens/wfx/persistence"
@@ -103,6 +105,65 @@ func TestJobDeleteTagsNonExisting(t *testing.T, db persistence.Storage) {
 
 	assert.Equal(t, oldTags, updatedJob.Tags)
 	assert.Len(t, *updatedJob.Tags, count)
+}
+
+func TestJobAddTagsConcurrent(t *testing.T, db persistence.Storage) {
+	// Two jobs concurrently add the SAME brand-new tag name.
+	// Without out-of-transaction tag resolution this races on the UNIQUE(name) index and one transaction fails with a constraint violation.
+	// Neither caller should observe such an error.
+	const newTag = "shared-new-tag"
+
+	tmp1 := newValidJob(defaultClientID)
+	_, err := db.CreateWorkflow(t.Context(), tmp1.Workflow)
+	require.NoError(t, err)
+	job1, err := db.CreateJob(t.Context(), tmp1)
+	require.NoError(t, err)
+
+	tmp2 := newValidJob(defaultClientID + "-2")
+	job2, err := db.CreateJob(t.Context(), tmp2)
+	require.NoError(t, err)
+
+	const writers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := range writers {
+		j := job1
+		if i%2 == 1 {
+			j = job2
+		}
+		// Each writer adds the shared tag plus a unique one so CreateBulk
+		// has multiple inserts to coordinate.
+		add := []string{newTag, fmt.Sprintf("uniq-%d", i)}
+		wg.Go(func() {
+			<-start
+			_, err := db.UpdateJob(t.Context(), j, persistence.JobUpdate{
+				AddTags: &add,
+			})
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		// Concurrent updates on the SAME job will be rejected by the mtime guard with errkind.TOCTOU; that is expected.
+		// What we assert here is that no caller fails with a unique-constraint violation from the global tag table.
+		if err != nil {
+			assert.NotContains(t, err.Error(), "UNIQUE constraint",
+				"tag insertion must not race against UNIQUE(name)")
+			assert.NotContains(t, err.Error(), "duplicate key",
+				"tag insertion must not race against UNIQUE(name)")
+		}
+	}
+
+	// Verify the shared tag is attached to both jobs.
+	final1, err := db.GetJob(t.Context(), job1.ID, persistence.FetchParams{})
+	require.NoError(t, err)
+	final2, err := db.GetJob(t.Context(), job2.ID, persistence.FetchParams{})
+	require.NoError(t, err)
+	assert.Contains(t, *final1.Tags, newTag)
+	assert.Contains(t, *final2.Tags, newTag)
 }
 
 func TestJobReuseExistingTags(t *testing.T, db persistence.Storage) {

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ build:
     go build -C contrib/config-deployment/client
 
 test:
-    go test -tags testing,no_mysql,no_postgres ./...
+    go test -count=1 -race -tags testing,no_mysql,no_postgres ./...
 
 # Update dependencies
 update-deps:
@@ -160,6 +160,10 @@ postgres-start:
 @postgres-shell:
     {{ DOCKER }} exec -it wfx-postgres psql -d $PGDATABASE -U $PGUSER
 
+# Run PostgreSQL tests
+postgres-test:
+    go test -count=1 -race -tags testing,no_mysql ./...
+
 # Stop PostgreSQL container
 postgres-stop: (_container-stop "wfx-postgres")
 
@@ -221,6 +225,10 @@ mysql-stop: (_container-stop "wfx-mysql")
 # Enter MySQL shell
 mysql-shell:
     {{ DOCKER }} exec -it wfx-mysql mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -D $MYSQL_DATABASE
+
+# Run MySQL tests
+mysql-test:
+    go test -count=1 -race -tags testing,no_postgres ./...
 
 # Generate schema definitions for MySQL
 mysql-generate-schema name:


### PR DESCRIPTION
### Description

1. Two callers concurrently transitioning the same job from state A could
both observe A, both validate, and both commit - silently overwriting
each other (TOCTOU).
The solution is to use optimistic concurrency control: extend the UPDATE
with WHERE `mtime = <observed mtime>`. If a concurrent writer has bumped
mtime the predicate fails and we translate that into a clear conflict
error. This is portable across all supported backends and adds no
contention.

2. When two UpdateJob calls on different jobs added the same brand-new tag
name, both transactions could see the tag row as missing and race to
insert it on the UNIQUE(name) index. The loser aborted with a constraint
violation, which in PostgreSQL also poisons the entire enclosing
transaction.
Resolve and create tag rows outside the job-update transaction, swallow
the benign duplicate-key error, and re-fetch.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
