### PR TITLE
feat(api): add response filter limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report failing JQ response filters as HTTP 400 (`wfx.invalidResponseFilter`) instead of 500
 
+### Fixed
+
+- Apply reloaded SSE ping and grace intervals to new job event connections
+
 ## [0.6.0] - 2026-06-03
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
+- `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
+
+### Changed
+
+- Report failing JQ response filters as HTTP 400 (`wfx.invalidResponseFilter`) instead of 500
+
 ## [0.6.0] - 2026-06-03
 
 ### Breaking

--- a/api/errors.go
+++ b/api/errors.go
@@ -47,3 +47,9 @@ var JobModifiedConcurrently = api.Error{
 	Logref:  "dc00b05825b44934afeb9454f42a6440",
 	Message: "Job was modified concurrently",
 }
+
+var InvalidResponseFilter = api.Error{
+	Code:    "wfx.invalidResponseFilter",
+	Logref:  "731cdc2ae765e840fbd675f15abace97",
+	Message: "The response filter could not be applied",
+}

--- a/api/jq.go
+++ b/api/jq.go
@@ -9,32 +9,44 @@ package api
  */
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/Southclaws/fault"
 	"github.com/itchyny/gojq"
 	"github.com/rs/zerolog/log"
+	"github.com/siemens/wfx/cmd/wfx/cmd/config"
+	"github.com/siemens/wfx/generated/api"
 )
 
 // JQFilter applies a JQ filter to the response body.
 type JQFilter struct {
+	ctx    context.Context
 	filter string
 	body   any
+	opts   config.JQOpts
 }
 
-func NewJQFilter(filter string, body any) JQFilter {
-	return JQFilter{filter: filter, body: body}
+func NewJQFilter(ctx context.Context, filter string, body any, opts config.JQOpts) JQFilter {
+	return JQFilter{ctx: ctx, filter: filter, body: body, opts: opts}
 }
 
-func applyFilter(w http.ResponseWriter, body any, filter string) error {
+func applyFilter(ctx context.Context, w http.ResponseWriter, body any, filter string, opts config.JQOpts) error {
 	contextLogger := log.With().Str("filter", filter).Logger()
 	contextLogger.Debug().Msg("Applying JQ filter")
 
 	query, err := gojq.Parse(filter)
 	if err != nil {
 		contextLogger.Err(err).Msg("Failed to parse JQ filter")
-		return fault.Wrap(err)
+		return writeFilterError(w, err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		contextLogger.Err(err).Msg("Failed to compile JQ filter")
+		return writeFilterError(w, err)
 	}
 
 	jsonData, err := json.Marshal(body)
@@ -48,17 +60,71 @@ func applyFilter(w http.ResponseWriter, body any, filter string) error {
 	// valid JSON
 	_ = json.Unmarshal(jsonData, &input)
 
-	w.Header().Set("X-Response-Filter", filter)
-	iter := query.Run(input)
-	ok := true
-	encoder := json.NewEncoder(w)
-	for ok {
-		var v any
-		v, ok = iter.Next()
-		if ok {
-			// this cannot fail because we know the input
-			_ = encoder.Encode(v)
+	filterCtx := ctx
+	if timeout := opts.FilterTimeout; timeout > 0 {
+		var cancel context.CancelFunc
+		filterCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	iter := code.RunWithContext(filterCtx, input)
+	// buffer the result so that a mid-stream error can still be turned into an
+	// error response instead of a partially written 200
+	buf := limitedBuffer{max: opts.FilterMaxResponseSize}
+	encoder := json.NewEncoder(&buf)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
 		}
+		if err, ok := v.(error); ok {
+			contextLogger.Err(err).Msg("Failed to execute JQ filter")
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				// the client is gone, don't bother writing a response
+				return fault.Wrap(ctxErr)
+			}
+			return writeFilterError(w, err)
+		}
+		if err := encoder.Encode(v); err != nil {
+			if errors.Is(err, errFilterResultTooLarge) {
+				contextLogger.Error().Int("maxSize", opts.FilterMaxResponseSize).Msg("JQ filter result too large")
+				return writeFilterError(w, err)
+			}
+			return fault.Wrap(err)
+		}
+	}
+	w.Header().Set("X-Response-Filter", filter)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		// response is already (partially) written, nothing left to do but log
+		contextLogger.Err(err).Msg("Failed to write filtered response")
+	}
+	return nil
+}
+
+var errFilterResultTooLarge = errors.New("response filter result exceeds size limit")
+
+type limitedBuffer struct {
+	bytes.Buffer
+	max int
+}
+
+func (buf *limitedBuffer) Write(p []byte) (int, error) {
+	if buf.max > 0 && len(p) > buf.max-buf.Len() {
+		return 0, errFilterResultTooLarge
+	}
+	n, err := buf.Buffer.Write(p)
+	return n, fault.Wrap(err)
+}
+
+// writeFilterError reports a faulty client-supplied filter as HTTP 400.
+func writeFilterError(w http.ResponseWriter, cause error) error {
+	apiErr := InvalidResponseFilter
+	apiErr.Message = cause.Error()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	if err := json.NewEncoder(w).Encode(api.ErrorResponse{
+		Errors: &[]api.Error{apiErr},
+	}); err != nil {
+		return fault.Wrap(err)
 	}
 	return nil
 }
@@ -67,73 +133,73 @@ func applyFilter(w http.ResponseWriter, body any, filter string) error {
 
 //revive:disable:var-naming
 func (jq JQFilter) VisitGetHealthResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitPostJobsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsEventsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitDeleteJobsIdResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsIdResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsIdDefinitionResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitPutJobsIdDefinitionResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsIdStatusResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitPutJobsIdStatusResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitDeleteJobsIdTagsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetJobsIdTagsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitPostJobsIdTagsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetVersionResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetWorkflowsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitPostWorkflowsResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitDeleteWorkflowsNameResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }
 
 func (jq JQFilter) VisitGetWorkflowsNameResponse(w http.ResponseWriter) error {
-	return applyFilter(w, jq.body, jq.filter)
+	return applyFilter(jq.ctx, w, jq.body, jq.filter, jq.opts)
 }

--- a/api/jq_test.go
+++ b/api/jq_test.go
@@ -9,20 +9,25 @@ package api
  */
 
 import (
+	"context"
 	"errors"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/siemens/wfx/cmd/wfx/cmd/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVisitMethod(t *testing.T) {
 	obj := map[string]string{"foo": "bar"}
 	filter := `.foo`
-	jqFilter := NewJQFilter(filter, obj)
+	jqFilter := NewJQFilter(t.Context(), filter, obj, config.JQOpts{FilterTimeout: time.Minute})
 
 	// Get the type and value of the struct
 	structType := reflect.TypeOf(jqFilter)
@@ -50,8 +55,11 @@ func TestVisitMethod(t *testing.T) {
 }
 
 func TestApplyFilterInvalid(t *testing.T) {
-	err := applyFilter(nil, nil, "invalid filter")
-	assert.Error(t, err)
+	recorder := httptest.NewRecorder()
+	err := applyFilter(t.Context(), recorder, nil, "invalid filter", config.JQOpts{FilterTimeout: time.Minute})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "wfx.invalidResponseFilter")
 }
 
 type NoMarshal struct{}
@@ -61,6 +69,87 @@ func (NoMarshal) MarshalJSON() ([]byte, error) {
 }
 
 func TestApplyFilterMarshalError(t *testing.T) {
-	err := applyFilter(nil, NoMarshal{}, "")
+	err := applyFilter(t.Context(), nil, NoMarshal{}, ".", config.JQOpts{FilterTimeout: time.Minute})
 	assert.Error(t, err)
+}
+
+func TestApplyFilterRuntimeError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	err := applyFilter(t.Context(), recorder, nil, `1, error("boom")`, config.JQOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	// no part of the successful output must leak into the error response
+	assert.NotContains(t, recorder.Body.String(), "1\n")
+	assert.Empty(t, recorder.Header().Get("X-Response-Filter"))
+}
+
+func TestApplyFilterResultTooLarge(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	maxResponseSize := 1024
+	err := applyFilter(t.Context(), recorder, nil, "range(0; 1000000000)", config.JQOpts{FilterMaxResponseSize: maxResponseSize})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "wfx.invalidResponseFilter")
+	assert.Less(t, recorder.Body.Len(), maxResponseSize)
+}
+
+func TestLimitedBufferRejectsOversizedWrite(t *testing.T) {
+	buf := limitedBuffer{max: 4}
+
+	n, err := buf.Write([]byte("12345"))
+
+	assert.Zero(t, n)
+	assert.ErrorIs(t, err, errFilterResultTooLarge)
+	assert.Zero(t, buf.Len())
+}
+
+func TestApplyFilterUsesRequestContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	recorder := httptest.NewRecorder()
+
+	err := applyFilter(ctx, recorder, map[string]string{"foo": "bar"}, ".foo", config.JQOpts{FilterTimeout: time.Minute})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, recorder.Body.String())
+}
+
+func TestApplyFilterCancelsLongRunningFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	recorder := httptest.NewRecorder()
+	started := time.Now()
+
+	err := applyFilter(ctx, recorder, nil, "repeat(0)", config.JQOpts{FilterTimeout: time.Minute})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), time.Second)
+}
+
+func TestApplyFilterTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	started := time.Now()
+
+	err := applyFilter(t.Context(), recorder, nil, "repeat(0)", config.JQOpts{FilterTimeout: 10 * time.Millisecond})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), context.DeadlineExceeded.Error())
+	assert.Less(t, time.Since(started), time.Second)
+}
+
+func TestApplyFilterNoTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	err := applyFilter(t.Context(), recorder, map[string]string{"foo": "bar"}, ".foo", config.JQOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "\"bar\"\n", recorder.Body.String())
 }

--- a/api/wfx.go
+++ b/api/wfx.go
@@ -48,6 +48,7 @@ type WfxServer struct {
 	storage persistence.Storage
 	checker health.Checker
 	sseOpts SSEOpts
+	jqOpts  func() config.JQOpts
 }
 
 type SSEOpts struct {
@@ -74,12 +75,23 @@ func NewWfxServer(storage persistence.Storage) *WfxServer {
 			PingInterval:  config.DefaultSSEPingInterval,
 			GraceInterval: config.DefaultSSEGraceInterval,
 		},
+		jqOpts: func() config.JQOpts {
+			return config.JQOpts{
+				FilterTimeout:         config.DefaultJQFilterTimeout,
+				FilterMaxResponseSize: config.DefaultJQFilterMaxResponseSize,
+			}
+		},
 	}
 	return wfx
 }
 
 func (server *WfxServer) WithSSEOpts(sseOpts SSEOpts) *WfxServer {
 	server.sseOpts = sseOpts
+	return server
+}
+
+func (server *WfxServer) WithJQOpts(jqOpts func() config.JQOpts) *WfxServer {
+	server.jqOpts = jqOpts
 	return server
 }
 
@@ -142,7 +154,7 @@ func (server WfxServer) GetJobs(ctx context.Context, request api.GetJobsRequestO
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *jobs), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *jobs, server.jqOpts()), nil
 	}
 	return api.GetJobs200JSONResponse(*jobs), nil
 }
@@ -162,7 +174,7 @@ func (server WfxServer) PostJobs(ctx context.Context, request api.PostJobsReques
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *job), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *job, server.jqOpts()), nil
 	}
 	return api.PostJobs201JSONResponse(*job), nil
 }
@@ -234,7 +246,7 @@ func (server WfxServer) GetJobsId(ctx context.Context, request api.GetJobsIdRequ
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *job), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *job, server.jqOpts()), nil
 	}
 	return api.GetJobsId200JSONResponse(*job), nil
 }
@@ -250,7 +262,7 @@ func (server WfxServer) GetJobsIdDefinition(ctx context.Context, request api.Get
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, definition), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, definition, server.jqOpts()), nil
 	}
 	return api.GetJobsIdDefinition200JSONResponse(definition), nil
 }
@@ -278,7 +290,7 @@ func (server WfxServer) PutJobsIdDefinition(ctx context.Context, request api.Put
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, definition), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, definition, server.jqOpts()), nil
 	}
 	return api.PutJobsIdDefinition200JSONResponse(definition), nil
 }
@@ -294,7 +306,7 @@ func (server WfxServer) GetJobsIdStatus(ctx context.Context, request api.GetJobs
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *status), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *status, server.jqOpts()), nil
 	}
 	return api.GetJobsIdStatus200JSONResponse(*status), nil
 }
@@ -332,7 +344,7 @@ func (server WfxServer) PutJobsIdStatus(ctx context.Context, request api.PutJobs
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *status), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *status, server.jqOpts()), nil
 	}
 	return api.PutJobsIdStatus200JSONResponse(*status), nil
 }
@@ -363,7 +375,7 @@ func (server WfxServer) DeleteJobsIdTags(ctx context.Context, request api.Delete
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, tags), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, tags, server.jqOpts()), nil
 	}
 
 	var tagsVal []string
@@ -384,7 +396,7 @@ func (server WfxServer) GetJobsIdTags(ctx context.Context, request api.GetJobsId
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, tags), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, tags, server.jqOpts()), nil
 	}
 
 	var tagsVal []string
@@ -417,7 +429,7 @@ func (server WfxServer) PostJobsIdTags(ctx context.Context, request api.PostJobs
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, tags), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, tags, server.jqOpts()), nil
 	}
 
 	var tagsVal []string
@@ -448,7 +460,7 @@ func (server WfxServer) GetWorkflows(ctx context.Context, request api.GetWorkflo
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *workflows), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *workflows, server.jqOpts()), nil
 	}
 	return api.GetWorkflows200JSONResponse(*workflows), nil
 }
@@ -474,7 +486,7 @@ func (server WfxServer) PostWorkflows(ctx context.Context, request api.PostWorkf
 		}
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, wf), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, wf, server.jqOpts()), nil
 	}
 	return api.PostWorkflows201JSONResponse(*wf), nil
 }
@@ -505,7 +517,7 @@ func (server WfxServer) GetWorkflowsName(ctx context.Context, request api.GetWor
 		return nil, fault.Wrap(err)
 	}
 	if request.Params.XResponseFilter != nil {
-		return NewJQFilter(*request.Params.XResponseFilter, *workflow), nil
+		return NewJQFilter(ctx, *request.Params.XResponseFilter, *workflow, server.jqOpts()), nil
 	}
 	return api.GetWorkflowsName200JSONResponse(*workflow), nil
 }

--- a/api/wfx.go
+++ b/api/wfx.go
@@ -47,7 +47,7 @@ var _ api.StrictServerInterface = (*WfxServer)(nil)
 type WfxServer struct {
 	storage persistence.Storage
 	checker health.Checker
-	sseOpts SSEOpts
+	sseOpts func() SSEOpts
 	jqOpts  func() config.JQOpts
 }
 
@@ -71,9 +71,11 @@ func NewWfxServer(storage persistence.Storage) *WfxServer {
 	wfx := &WfxServer{
 		storage: storage,
 		checker: checker,
-		sseOpts: SSEOpts{
-			PingInterval:  config.DefaultSSEPingInterval,
-			GraceInterval: config.DefaultSSEGraceInterval,
+		sseOpts: func() SSEOpts {
+			return SSEOpts{
+				PingInterval:  config.DefaultSSEPingInterval,
+				GraceInterval: config.DefaultSSEGraceInterval,
+			}
 		},
 		jqOpts: func() config.JQOpts {
 			return config.JQOpts{
@@ -85,7 +87,7 @@ func NewWfxServer(storage persistence.Storage) *WfxServer {
 	return wfx
 }
 
-func (server *WfxServer) WithSSEOpts(sseOpts SSEOpts) *WfxServer {
+func (server *WfxServer) WithSSEOpts(sseOpts func() SSEOpts) *WfxServer {
 	server.sseOpts = sseOpts
 	return server
 }
@@ -217,8 +219,9 @@ func (server WfxServer) GetJobsEvents(ctx context.Context, request api.GetJobsEv
 	if s := request.Params.Tags; s != nil {
 		tags = strings.Split(*s, ",")
 	}
-	subscriber := events.AddSubscriber(ctx, server.sseOpts.GraceInterval, filter, tags)
-	return sse.NewResponder(ctx, server.sseOpts.PingInterval, subscriber), nil
+	sseOpts := server.sseOpts()
+	subscriber := events.AddSubscriber(ctx, sseOpts.GraceInterval, filter, tags)
+	return sse.NewResponder(ctx, sseOpts.PingInterval, subscriber), nil
 }
 
 func (server WfxServer) DeleteJobsId(ctx context.Context, request api.DeleteJobsIdRequestObject) (api.DeleteJobsIdResponseObject, error) {

--- a/api/wfx_test.go
+++ b/api/wfx_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alexliesenfeld/health"
 	"github.com/siemens/wfx/cmd/wfx/cmd/config"
@@ -44,6 +45,15 @@ func TestJQOptsProvider(t *testing.T) {
 	assert.Equal(t, 1, wfx.jqOpts().FilterMaxResponseSize)
 	opts.FilterMaxResponseSize = 2
 	assert.Equal(t, 2, wfx.jqOpts().FilterMaxResponseSize)
+}
+
+func TestSSEOptsProvider(t *testing.T) {
+	opts := SSEOpts{PingInterval: time.Second}
+	wfx := NewWfxServer(persistence.NewHealthyMockStorage(t)).WithSSEOpts(func() SSEOpts { return opts })
+
+	assert.Equal(t, time.Second, wfx.sseOpts().PingInterval)
+	opts.PingInterval = 2 * time.Second
+	assert.Equal(t, 2*time.Second, wfx.sseOpts().PingInterval)
 }
 
 func TestGetJobsEvents(t *testing.T) {

--- a/api/wfx_test.go
+++ b/api/wfx_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/alexliesenfeld/health"
+	"github.com/siemens/wfx/cmd/wfx/cmd/config"
 	"github.com/siemens/wfx/generated/api"
 	"github.com/siemens/wfx/internal/persistence/entgo"
 	"github.com/siemens/wfx/persistence"
@@ -34,6 +35,15 @@ func TestStatusListener(*testing.T) {
 			"db": {Status: health.StatusUp},
 		},
 	})
+}
+
+func TestJQOptsProvider(t *testing.T) {
+	opts := config.JQOpts{FilterMaxResponseSize: 1}
+	wfx := NewWfxServer(persistence.NewHealthyMockStorage(t)).WithJQOpts(func() config.JQOpts { return opts })
+
+	assert.Equal(t, 1, wfx.jqOpts().FilterMaxResponseSize)
+	opts.FilterMaxResponseSize = 2
+	assert.Equal(t, 2, wfx.jqOpts().FilterMaxResponseSize)
 }
 
 func TestGetJobsEvents(t *testing.T) {

--- a/cmd/wfx/cmd/config/appconfig.go
+++ b/cmd/wfx/cmd/config/appconfig.go
@@ -46,9 +46,11 @@ type AppConfig struct {
 	ssePingInterval  time.Duration
 	sseGraceInterval time.Duration
 
-	maxHeaderSize  int
-	readTimeout    time.Duration
-	writeTimeout   time.Duration
+	maxHeaderSize int
+	readTimeout   time.Duration
+	writeTimeout  time.Duration
+	jqOpts        JQOpts
+
 	keepAlive      bool
 	cleanupTimeout time.Duration
 
@@ -69,6 +71,11 @@ type AppConfig struct {
 	mgmtTLSPort    int
 	mgmtUnixSocket string
 	mgmtPluginsDir string
+}
+
+type JQOpts struct {
+	FilterTimeout         time.Duration
+	FilterMaxResponseSize int
 }
 
 type Scheme int
@@ -250,6 +257,16 @@ func (cfg *AppConfig) Reload() bool {
 	cfg.maxHeaderSize = cfg.k.Int(MaxHeaderSizeFlag)
 	cfg.readTimeout = cfg.k.Duration(ReadTimeoutFlag)
 	cfg.writeTimeout = cfg.k.Duration(WriteTimoutFlag)
+	cfg.jqOpts.FilterTimeout = cfg.k.Duration(JQFilterTimeoutFlag)
+	cfg.jqOpts.FilterMaxResponseSize = cfg.k.Int(JQFilterMaxResponseSizeFlag)
+	if cfg.jqOpts.FilterTimeout < 0 {
+		log.Error().Msgf("%s must not be negative", JQFilterTimeoutFlag)
+		ok = false
+	}
+	if cfg.jqOpts.FilterMaxResponseSize < 0 {
+		log.Error().Msgf("%s must not be negative", JQFilterMaxResponseSizeFlag)
+		ok = false
+	}
 	cfg.cleanupTimeout = cfg.k.Duration(CleanupTimeoutFlag)
 	cfg.keepAlive = cfg.k.Bool(KeepAliveFlag)
 
@@ -304,6 +321,12 @@ func (cfg *AppConfig) WriteTimeout() time.Duration {
 	cfg.mutex.RLock()
 	defer cfg.mutex.RUnlock()
 	return cfg.writeTimeout
+}
+
+func (cfg *AppConfig) JQOpts() JQOpts {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return cfg.jqOpts
 }
 
 func (cfg *AppConfig) KeepAlive() bool {

--- a/cmd/wfx/cmd/config/appconfig_test.go
+++ b/cmd/wfx/cmd/config/appconfig_test.go
@@ -52,6 +52,21 @@ func TestNewAppConfig_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewAppConfigNegativeJQLimit(t *testing.T) {
+	for _, args := range [][]string{
+		{"--" + JQFilterTimeoutFlag, "-1s"},
+		{"--" + JQFilterMaxResponseSizeFlag, "-1"},
+	} {
+		flags := NewFlagset()
+		require.NoError(t, flags.Parse(args))
+
+		cfg, err := NewAppConfig(flags)
+
+		assert.Nil(t, cfg)
+		assert.Error(t, err)
+	}
+}
+
 func TestReload(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "TestReload")
 	cfgFile, _ := os.CreateTemp("", "config.yaml")

--- a/cmd/wfx/cmd/config/flags.go
+++ b/cmd/wfx/cmd/config/flags.go
@@ -48,13 +48,15 @@ const (
 	MgmtUnixSocketFlag = "mgmt-unix-socket"
 	MgmtPluginsDirFlag = "mgmt-plugins-dir"
 
-	SchemeFlag          = "scheme"
-	KeepAliveFlag       = "keep-alive"
-	MaxHeaderSizeFlag   = "max-header-size"
-	CleanupTimeoutFlag  = "cleanup-timeout"
-	GracefulTimeoutFlag = "graceful-timeout"
-	ReadTimeoutFlag     = "read-timeout"
-	WriteTimoutFlag     = "write-timeout"
+	SchemeFlag                  = "scheme"
+	KeepAliveFlag               = "keep-alive"
+	MaxHeaderSizeFlag           = "max-header-size"
+	CleanupTimeoutFlag          = "cleanup-timeout"
+	GracefulTimeoutFlag         = "graceful-timeout"
+	ReadTimeoutFlag             = "read-timeout"
+	WriteTimoutFlag             = "write-timeout"
+	JQFilterTimeoutFlag         = "jq-filter-timeout"
+	JQFilterMaxResponseSizeFlag = "jq-filter-max-response-size"
 
 	SSEPingIntervalFlag  = "sse-ping-interval"
 	SSEGraceIntervalFlag = "sse-grace-interval"
@@ -73,6 +75,9 @@ const (
 	// some reverse proxy)
 	DefaultSSEPingInterval  = 30 * time.Second
 	DefaultSSEGraceInterval = time.Minute
+
+	DefaultJQFilterTimeout         = 30 * time.Second
+	DefaultJQFilterMaxResponseSize = 16 << 20 // 16 MiB
 )
 
 func NewFlagset() *pflag.FlagSet {
@@ -90,6 +95,8 @@ func NewFlagset() *pflag.FlagSet {
 	f.Bool(KeepAliveFlag, true, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
 	f.Duration(ReadTimeoutFlag, 30*time.Second, "maximum duration before timing out read of the request")
 	f.Duration(WriteTimoutFlag, 10*time.Minute, "maximum duration before timing out write of the response")
+	f.Duration(JQFilterTimeoutFlag, DefaultJQFilterTimeout, "maximum duration for applying a JQ response filter (0 = no limit)")
+	f.Int(JQFilterMaxResponseSizeFlag, DefaultJQFilterMaxResponseSize, "maximum size in bytes of a JQ response filter result (0 = no limit)")
 	f.String(SimpleFileServerFlag, "", "root directory for built-in fileserver (available under /download)")
 
 	f.String(TLSCertificateFlag, "", "the certificate file to use for secure connections")

--- a/cmd/wfx/cmd/config/flags_test.go
+++ b/cmd/wfx/cmd/config/flags_test.go
@@ -10,11 +10,29 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultConfigFiles(t *testing.T) {
 	fnames := DefaultConfigFiles()
 	assert.NotEmpty(t, fnames)
+}
+
+func TestJQFilterTimeoutFlag(t *testing.T) {
+	flags := NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + JQFilterTimeoutFlag, "5s"}))
+	timeout, err := flags.GetDuration(JQFilterTimeoutFlag)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, timeout)
+}
+
+func TestJQFilterMaxResponseSizeFlag(t *testing.T) {
+	flags := NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + JQFilterMaxResponseSizeFlag, "1024"}))
+	maxResponseSize, err := flags.GetInt(JQFilterMaxResponseSizeFlag)
+	require.NoError(t, err)
+	assert.Equal(t, 1024, maxResponseSize)
 }

--- a/cmd/wfx/cmd/root/root.go
+++ b/cmd/wfx/cmd/root/root.go
@@ -85,9 +85,11 @@ Examples of tasks are installation of firmware or other types of commands issued
 			chErr := make(chan error, 1)
 
 			wfx := api.NewWfxServer(storage).
-				WithSSEOpts(api.SSEOpts{
-					PingInterval:  cfg.SSEPingInterval(),
-					GraceInterval: cfg.SSEGraceInterval(),
+				WithSSEOpts(func() api.SSEOpts {
+					return api.SSEOpts{
+						PingInterval:  cfg.SSEPingInterval(),
+						GraceInterval: cfg.SSEGraceInterval(),
+					}
 				}).
 				WithJQOpts(cfg.JQOpts)
 			wfx.Start()

--- a/cmd/wfx/cmd/root/root.go
+++ b/cmd/wfx/cmd/root/root.go
@@ -88,7 +88,8 @@ Examples of tasks are installation of firmware or other types of commands issued
 				WithSSEOpts(api.SSEOpts{
 					PingInterval:  cfg.SSEPingInterval(),
 					GraceInterval: cfg.SSEGraceInterval(),
-				})
+				}).
+				WithJQOpts(cfg.JQOpts)
 			wfx.Start()
 			defer wfx.Stop()
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -215,6 +215,9 @@ returns the current `state` of the job as a string.
 Note that the (filtered) response might no longer be a valid JSON expression as is the case in this example.
 It's the client's responsibility to handle the filtered response properly ― which it asked for being filtered in the first place.
 
+Filters are executed with a time limit (`--jq-filter-timeout`, default 30s; `0` disables the limit) and their result is capped by `--jq-filter-max-response-size` (default 16 MiB; `0` disables the limit).
+A filter which is invalid, fails at runtime, times out or exceeds the size limit results in an HTTP 400 response with error code `wfx.invalidResponseFilter`; no partial response body is ever emitted.
+
 ### Health Check
 
 wfx includes an internal health check service that's accessible at `/health`, e.g., via

--- a/justfile
+++ b/justfile
@@ -67,7 +67,6 @@ docs-serve:
 lint:
     #!/usr/bin/env bash
     set -euo pipefail
-    export CGO_ENABLED=0
     golangci-lint run -v
     staticcheck -tags=testing ./...
     go list ./... 2>/dev/null | sed -e 's,github.com/siemens/wfx/,,' | grep -v "^generated" | sort | uniq | while read -r pkg; do


### PR DESCRIPTION
### Description

Add configurable time and output-size limits for JQ response filters, and return HTTP 400 when filters fail without emitting partial output.

These limits provide operational safeguards, not a security boundary. Per the documented trust model, an API gateway authenticates and authorizes clients before requests reach wfx.

While at it, also fix config reload support for SSE intervals (separate commit).

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [X] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

#### Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [X] My changes adhere to the established code style, patterns, and best practices.
- [X] I have added tests that demonstrate the effectiveness of my changes.
- [X] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
