### PR TITLE
feat: make CORS headers configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
-- Configurable CORS headers (`--cors-allowed-origins`, `--cors-allowed-methods`, `--cors-allowed-headers`)
+- Configurable CORS headers (`--cors-allowed-origins`, `--cors-allowed-methods`, `--cors-allowed-headers`, `--cors-allow-credentials` and `--cors-max-age` flags)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
+- Configurable CORS headers (`--cors-allowed-origins`, `--cors-allowed-methods`, `--cors-allowed-headers`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Apply reloaded SSE ping and grace intervals to new job event connections
+- CORS is registered globally now
 
 ## [0.6.0] - 2026-06-03
 

--- a/cmd/wfx/cmd/config/appconfig.go
+++ b/cmd/wfx/cmd/config/appconfig.go
@@ -55,9 +55,11 @@ type AppConfig struct {
 	keepAlive      bool
 	cleanupTimeout time.Duration
 
-	corsAllowedOrigins []string
-	corsAllowedMethods []string
-	corsAllowedHeaders []string
+	corsAllowedOrigins   []string
+	corsAllowedMethods   []string
+	corsAllowedHeaders   []string
+	corsAllowCredentials bool
+	corsMaxAge           time.Duration
 
 	tlsCACertificate string
 	tlsCertificate   string
@@ -241,6 +243,12 @@ func (cfg *AppConfig) Reload() bool {
 	cfg.corsAllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
 	cfg.corsAllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
 	cfg.corsAllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
+	cfg.corsAllowCredentials = cfg.k.Bool(CORSAllowCredentialsFlag)
+	cfg.corsMaxAge = cfg.k.Duration(CORSMaxAgeFlag)
+	if cfg.corsAllowCredentials && slices.Contains(cfg.corsAllowedOrigins, "*") {
+		fmt.Fprintln(os.Stderr, "cors-allow-credentials requires explicit cors-allowed-origins")
+		ok = false
+	}
 
 	if schemes := cfg.k.Strings(SchemeFlag); len(schemes) > 0 {
 		cfg.schemes = make([]Scheme, 0, len(schemes))
@@ -468,6 +476,21 @@ func (cfg *AppConfig) CORSAllowedHeaders() []string {
 	cfg.mutex.RLock()
 	defer cfg.mutex.RUnlock()
 	return slices.Clone(cfg.corsAllowedHeaders)
+}
+
+func (cfg *AppConfig) CORSAllowCredentials() bool {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return cfg.corsAllowCredentials
+}
+
+// CORSMaxAge returns the preflight cache duration in seconds. Zero (the
+// default) omits the Access-Control-Max-Age header; a negative value forces
+// `Access-Control-Max-Age: 0` so browsers stop caching preflights.
+func (cfg *AppConfig) CORSMaxAge() int {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return int(cfg.corsMaxAge / time.Second)
 }
 
 func (cfg *AppConfig) InitStorage() (persistence.Storage, error) {

--- a/cmd/wfx/cmd/config/appconfig.go
+++ b/cmd/wfx/cmd/config/appconfig.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -53,6 +54,10 @@ type AppConfig struct {
 
 	keepAlive      bool
 	cleanupTimeout time.Duration
+
+	corsAllowedOrigins []string
+	corsAllowedMethods []string
+	corsAllowedHeaders []string
 
 	tlsCACertificate string
 	tlsCertificate   string
@@ -232,6 +237,10 @@ func (cfg *AppConfig) Reload() bool {
 	cfg.gracefulTimeout = cfg.k.Duration(GracefulTimeoutFlag)
 	cfg.ssePingInterval = cfg.k.Duration(SSEPingIntervalFlag)
 	cfg.sseGraceInterval = cfg.k.Duration(SSEGraceIntervalFlag)
+
+	cfg.corsAllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
+	cfg.corsAllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
+	cfg.corsAllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
 
 	if schemes := cfg.k.Strings(SchemeFlag); len(schemes) > 0 {
 		cfg.schemes = make([]Scheme, 0, len(schemes))
@@ -441,6 +450,24 @@ func (cfg *AppConfig) SSEGraceInterval() time.Duration {
 	cfg.mutex.RLock()
 	defer cfg.mutex.RUnlock()
 	return cfg.sseGraceInterval
+}
+
+func (cfg *AppConfig) CORSAllowedOrigins() []string {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return slices.Clone(cfg.corsAllowedOrigins)
+}
+
+func (cfg *AppConfig) CORSAllowedMethods() []string {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return slices.Clone(cfg.corsAllowedMethods)
+}
+
+func (cfg *AppConfig) CORSAllowedHeaders() []string {
+	cfg.mutex.RLock()
+	defer cfg.mutex.RUnlock()
+	return slices.Clone(cfg.corsAllowedHeaders)
 }
 
 func (cfg *AppConfig) InitStorage() (persistence.Storage, error) {

--- a/cmd/wfx/cmd/config/appconfig_test.go
+++ b/cmd/wfx/cmd/config/appconfig_test.go
@@ -67,6 +67,15 @@ func TestNewAppConfigNegativeJQLimit(t *testing.T) {
 	}
 }
 
+func TestNewAppConfig_CORSWildcardOriginWithCredentials(t *testing.T) {
+	flags := NewFlagset()
+	_ = flags.Parse([]string{"--" + CORSAllowCredentialsFlag})
+
+	cfg, err := NewAppConfig(flags)
+	assert.Nil(t, cfg)
+	assert.Error(t, err)
+}
+
 func TestReload(t *testing.T) {
 	dir, _ := os.MkdirTemp("", "TestReload")
 	cfgFile, _ := os.CreateTemp("", "config.yaml")

--- a/cmd/wfx/cmd/config/flags.go
+++ b/cmd/wfx/cmd/config/flags.go
@@ -61,9 +61,11 @@ const (
 	SSEPingIntervalFlag  = "sse-ping-interval"
 	SSEGraceIntervalFlag = "sse-grace-interval"
 
-	CORSAllowedOriginsFlag = "cors-allowed-origins"
-	CORSAllowedMethodsFlag = "cors-allowed-methods"
-	CORSAllowedHeadersFlag = "cors-allowed-headers"
+	CORSAllowedOriginsFlag   = "cors-allowed-origins"
+	CORSAllowedMethodsFlag   = "cors-allowed-methods"
+	CORSAllowedHeadersFlag   = "cors-allowed-headers"
+	CORSAllowCredentialsFlag = "cors-allow-credentials"
+	CORSMaxAgeFlag           = "cors-max-age"
 
 	TLSCaFlag          = "tls-ca"
 	TLSCertificateFlag = "tls-certificate"
@@ -101,6 +103,8 @@ func NewFlagset() *pflag.FlagSet {
 	f.StringSlice(CORSAllowedOriginsFlag, []string{"*"}, "one or multiple origins allowed to make cross-origin requests")
 	f.StringSlice(CORSAllowedMethodsFlag, defaultCORSAllowedMethods, "one or multiple methods allowed when making cross-origin requests")
 	f.StringSlice(CORSAllowedHeadersFlag, []string{"*"}, "one or multiple headers allowed when making cross-origin requests")
+	f.Bool(CORSAllowCredentialsFlag, false, "allow cookies and HTTP authentication to be included in cross-origin requests; requires explicit allowed origins")
+	f.Duration(CORSMaxAgeFlag, 0, "how long the results of preflight requests may be cached by browsers; zero omits the Access-Control-Max-Age header (browsers use their default), a negative value disables preflight caching")
 
 	f.Int(MaxHeaderSizeFlag, 1000000, "controls the maximum number of bytes the server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body")
 	f.Bool(KeepAliveFlag, true, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")

--- a/cmd/wfx/cmd/config/flags.go
+++ b/cmd/wfx/cmd/config/flags.go
@@ -61,6 +61,10 @@ const (
 	SSEPingIntervalFlag  = "sse-ping-interval"
 	SSEGraceIntervalFlag = "sse-grace-interval"
 
+	CORSAllowedOriginsFlag = "cors-allowed-origins"
+	CORSAllowedMethodsFlag = "cors-allowed-methods"
+	CORSAllowedHeadersFlag = "cors-allowed-headers"
+
 	TLSCaFlag          = "tls-ca"
 	TLSCertificateFlag = "tls-certificate"
 	TLSKeyFlag         = "tls-key"
@@ -80,6 +84,9 @@ const (
 	DefaultJQFilterMaxResponseSize = 16 << 20 // 16 MiB
 )
 
+// mirrors the defaults of cors.AllowAll()
+var defaultCORSAllowedMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}
+
 func NewFlagset() *pflag.FlagSet {
 	f := pflag.NewFlagSet("wfx", pflag.ExitOnError)
 
@@ -90,6 +97,10 @@ func NewFlagset() *pflag.FlagSet {
 	f.Duration(GracefulTimeoutFlag, 15*time.Second, "grace period for which to wait before shutting down the server")
 	f.Duration(SSEPingIntervalFlag, DefaultSSEPingInterval, "interval to send periodic keep-alive messages to prevent server-sent events connections from being closed due to inactivity")
 	f.Duration(SSEGraceIntervalFlag, DefaultSSEGraceInterval, "interval after which non-responsive subscribers are dropped")
+
+	f.StringSlice(CORSAllowedOriginsFlag, []string{"*"}, "one or multiple origins allowed to make cross-origin requests")
+	f.StringSlice(CORSAllowedMethodsFlag, defaultCORSAllowedMethods, "one or multiple methods allowed when making cross-origin requests")
+	f.StringSlice(CORSAllowedHeadersFlag, []string{"*"}, "one or multiple headers allowed when making cross-origin requests")
 
 	f.Int(MaxHeaderSizeFlag, 1000000, "controls the maximum number of bytes the server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body")
 	f.Bool(KeepAliveFlag, true, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,23 @@ The following connectivity parameters are available:
 | `--tls-key`         | The location of the TLS key file                                                  |
 | `--tls-ca`          | The certificate authority certificate file for mutual TLS authentication          |
 
+## Cross-Origin Resource Sharing (CORS)
+
+The API servers add CORS headers to responses, allowing browser-based clients to access wfx directly.
+The following parameters control these headers:
+
+| Parameter                | Description                                                                                              |
+| :----------------------- | :------------------------------------------------------------------------------------------------------- |
+| `--cors-allowed-origins` | One or multiple origins allowed to make cross-origin requests; defaults to `*` (any origin)              |
+| `--cors-allowed-methods` | One or multiple methods allowed when making cross-origin requests; defaults to `GET,HEAD,POST,PUT,PATCH,DELETE` |
+| `--cors-allowed-headers` | One or multiple headers allowed when making cross-origin requests; defaults to `*` (any header)          |
+
+For example, to restrict access to a single origin:
+
+```bash
+wfx --cors-allowed-origins https://wfx.example.com
+```
+
 ## File Server
 
 wfx comes with a built-in file server that serves artifacts at `http://<wfx host:{client,mgmt} port>/download/`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,11 +172,16 @@ The following connectivity parameters are available:
 The API servers add CORS headers to responses, allowing browser-based clients to access wfx directly.
 The following parameters control these headers:
 
-| Parameter                | Description                                                                                              |
-| :----------------------- | :------------------------------------------------------------------------------------------------------- |
-| `--cors-allowed-origins` | One or multiple origins allowed to make cross-origin requests; defaults to `*` (any origin)              |
-| `--cors-allowed-methods` | One or multiple methods allowed when making cross-origin requests; defaults to `GET,HEAD,POST,PUT,PATCH,DELETE` |
-| `--cors-allowed-headers` | One or multiple headers allowed when making cross-origin requests; defaults to `*` (any header)          |
+| Parameter                  | Description                                                                                                                                                                       |
+|:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cors-allowed-origins`   | One or multiple origins allowed to make cross-origin requests; defaults to `*` (any origin)                                                                                       |
+| `--cors-allowed-methods`   | One or multiple methods allowed when making cross-origin requests; defaults to `GET,HEAD,POST,PUT,PATCH,DELETE`                                                                   |
+| `--cors-allowed-headers`   | One or multiple headers allowed when making cross-origin requests; defaults to `*` (any header)                                                                                   |
+| `--cors-allow-credentials` | Allow cookies and HTTP authentication in cross-origin requests; disabled by default                                                                                               |
+| `--cors-max-age`           | How long browsers may cache preflight results (e.g. `12h`); zero omits the `Access-Control-Max-Age` header (browser default applies), a negative value disables preflight caching |
+
+`--cors-allow-credentials` requires explicit origins. Configuration is rejected if
+`--cors-allowed-origins` contains `*` while credentials are enabled.
 
 For example, to restrict access to a single origin:
 

--- a/internal/server/server_collection.go
+++ b/internal/server/server_collection.go
@@ -49,6 +49,8 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	swag, _ := api.GetSpec()
 	validator := nethttpmiddleware.OapiRequestValidatorWithOptions(swag,
 		&nethttpmiddleware.Options{SilenceServersWarning: true})
+	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
+	// route of our mux, so a per-route middleware would never see them.
 	corsMW := cors.New(cors.Options{
 		AllowedOrigins: cfg.CORSAllowedOrigins(),
 		AllowedMethods: cfg.CORSAllowedMethods(),
@@ -57,7 +59,7 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	logMW := logging.NewLoggingMiddleware()
 
 	// LIFO
-	middlewares := []api.MiddlewareFunc{validator, corsMW, logMW}
+	middlewares := []api.MiddlewareFunc{validator, logMW}
 
 	pluginMWs := make([]*plugin.Middleware, 0)
 	pluginErrors := make([]<-chan error, 0)
@@ -78,6 +80,7 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
+	northServer.Handler = corsMW(northServer.Handler)
 
 	southPluginMWs, err := createPluginMiddlewares(cfg.ClientPluginsDir())
 	if err != nil {
@@ -95,6 +98,7 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
+	southServer.Handler = corsMW(southServer.Handler)
 
 	return &ServerCollection{
 		cfg:          cfg,

--- a/internal/server/server_collection.go
+++ b/internal/server/server_collection.go
@@ -52,9 +52,11 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
 	// route of our mux, so a per-route middleware would never see them.
 	corsMW := cors.New(cors.Options{
-		AllowedOrigins: cfg.CORSAllowedOrigins(),
-		AllowedMethods: cfg.CORSAllowedMethods(),
-		AllowedHeaders: cfg.CORSAllowedHeaders(),
+		AllowedOrigins:   cfg.CORSAllowedOrigins(),
+		AllowedMethods:   cfg.CORSAllowedMethods(),
+		AllowedHeaders:   cfg.CORSAllowedHeaders(),
+		AllowCredentials: cfg.CORSAllowCredentials(),
+		MaxAge:           cfg.CORSMaxAge(),
 	}).Handler
 	logMW := logging.NewLoggingMiddleware()
 

--- a/internal/server/server_collection.go
+++ b/internal/server/server_collection.go
@@ -49,7 +49,11 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	swag, _ := api.GetSpec()
 	validator := nethttpmiddleware.OapiRequestValidatorWithOptions(swag,
 		&nethttpmiddleware.Options{SilenceServersWarning: true})
-	corsMW := cors.AllowAll().Handler
+	corsMW := cors.New(cors.Options{
+		AllowedOrigins: cfg.CORSAllowedOrigins(),
+		AllowedMethods: cfg.CORSAllowedMethods(),
+		AllowedHeaders: cfg.CORSAllowedHeaders(),
+	}).Handler
 	logMW := logging.NewLoggingMiddleware()
 
 	// LIFO

--- a/internal/server/server_collection_test.go
+++ b/internal/server/server_collection_test.go
@@ -94,6 +94,88 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	assert.Empty(t, result.Header.Get("Access-Control-Allow-Methods"))
 }
 
+func TestCORSAllowCredentials(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
+	wfx := api.NewWfxServer(dbMock)
+
+	f := config.NewFlagset()
+	_ = f.Parse([]string{
+		"--" + config.CORSAllowedOriginsFlag, "https://example.com",
+		"--" + config.CORSAllowCredentialsFlag,
+	})
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	// actual request
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	sc.North.Handler.ServeHTTP(rec, req)
+	result := rec.Result()
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+
+	// preflight request
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
+	sc.North.Handler.ServeHTTP(rec, req)
+	result = rec.Result()
+	assert.Equal(t, http.StatusNoContent, result.StatusCode)
+	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCORSMaxAge(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	f := config.NewFlagset()
+	_ = f.Parse([]string{"--" + config.CORSMaxAgeFlag, "30s"})
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, "30", rec.Result().Header.Get("Access-Control-Max-Age"))
+}
+
+func TestCORSMaxAgeDisabled(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	// default: no --cors-max-age flag, header must be omitted
+	f := config.NewFlagset()
+	_ = f.Parse(nil)
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	assert.Empty(t, rec.Result().Header.Get("Access-Control-Max-Age"))
+}
+
 func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)

--- a/internal/server/server_collection_test.go
+++ b/internal/server/server_collection_test.go
@@ -87,8 +87,36 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", "DELETE")
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	// disallowed method in preflight: cors middleware returns 405 without CORS headers
-	assert.Equal(t, http.StatusMethodNotAllowed, rec.Result().StatusCode)
+	// disallowed method in preflight: cors middleware answers without CORS headers,
+	// so the browser rejects the actual request
+	result := rec.Result()
+	assert.Empty(t, result.Header.Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, result.Header.Get("Access-Control-Allow-Methods"))
+}
+
+func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	f := config.NewFlagset()
+	_ = f.Parse([]string{})
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Set("Access-Control-Request-Headers", "Authorization")
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	result := rec.Result()
+	assert.Equal(t, "*", result.Header.Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, strings.ToLower(result.Header.Get("Access-Control-Allow-Headers")), "authorization")
 }
 
 func TestCreateServer_UseMiddlewares(t *testing.T) {

--- a/internal/server/server_collection_test.go
+++ b/internal/server/server_collection_test.go
@@ -36,6 +36,61 @@ func TestNewServerCollection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCORSConfigurableOrigins(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
+	wfx := api.NewWfxServer(dbMock)
+
+	f := config.NewFlagset()
+	_ = f.Parse([]string{"--" + config.CORSAllowedOriginsFlag, "https://example.com"})
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		origin   string
+		expected string
+	}{
+		{origin: "https://example.com", expected: "https://example.com"},
+		{origin: "https://evil.example.com", expected: ""},
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+		req.Header.Set("Origin", tc.origin)
+		sc.North.Handler.ServeHTTP(rec, req)
+
+		result := rec.Result()
+		assert.Equal(t, http.StatusOK, result.StatusCode)
+		assert.Equal(t, tc.expected, result.Header.Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestCORSPreflightAllowedMethods(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	f := config.NewFlagset()
+	_ = f.Parse([]string{"--" + config.CORSAllowedMethodsFlag, "GET"})
+	cfg, err := config.NewAppConfig(f)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "DELETE")
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	// disallowed method in preflight: cors middleware returns 405 without CORS headers
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Result().StatusCode)
+}
+
 func TestCreateServer_UseMiddlewares(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	dbMock.EXPECT().QueryJobs(context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)


### PR DESCRIPTION
### Description

1. CORS must wrap the whole server. CORS was registered as an api.MiddlewareFunc, i.e. per-route. OPTIONS /api/wfx/v1/jobs matches no route in the mux, so Go's ServeMux answered 405 itself and the CORS middleware never ran.

2. Replace hardcoded cors.AllowAll() with three new flags: `--cors-allowed-origins`, `--cors-allowed-methods` and
`--cors-allowed-headers`. Defaults keep the previous behavior (all origins, all standard methods).

3. Expose --cors-allow-credentials and --cors-max-age flags.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
