### PR TITLE
chore: devenv setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Siemens AG
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Michael Adler <michael.adler@siemens.com>
+#
+# NOTE: The following credentials are for local testing and CI. They are not sensitive.
+
+# Postgres CI
+PGUSER=wfx
+PGPASSWORD=secret
+PGHOST=localhost
+PGPORT=5432
+PGDATABASE=wfx
+PGSSLMODE=disable
+
+# MySQL CI
+MYSQL_USER=root
+MYSQL_PASSWORD=root
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=wfx
+MYSQL_HOST=localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-linux:
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -26,30 +26,36 @@ jobs:
       - uses: ./.github/actions/setup-ui
       - uses: ./.github/actions/setup-build
       - run: sudo .ci/setup-build.sh
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      # even though Windows is not officially supported, we want it to at least compile successfully
-      - name: Build for Windows
-        run: /usr/bin/env CC=$(pwd)/.ci/zcc goreleaser build --clean --single-target --snapshot
-        env:
-          GOOS: windows
-
       - name: Build Snapshot Release for Linux
         run: /usr/bin/env CC=$(pwd)/.ci/zcc goreleaser release --clean --snapshot
-
-      - name: build contrib
-        run: |
-          go build -C contrib/remote-access/client
-          go build -C contrib/config-deployment/client
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/**/*
           retention-days: 5
+
+  build-windows:
+    name: Build for Windows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/setup-ui
+      - uses: ./.github/actions/setup-build
+      - run: sudo .ci/setup-build.sh
+      # even though Windows is not officially supported, we want it to at least compile successfully
+      - run: /usr/bin/env CC="$(pwd)/.ci/zcc" goreleaser build --clean --single-target --snapshot
+        env:
+          GOOS: windows
+
+  build-contrib:
+    name: Build Contrib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/setup-build
+      - run: |
+          go build -C contrib/remote-access/client
+          go build -C contrib/config-deployment/client
 
   go-unit-test:
     name: Go Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ coverage*
 *.exe
 *.sbom.json
 .direnv
+.devenv*
+devenv.local.nix
+devenv.local.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1787835476,
+        "narHash": "sha256-tc6J64eu7vh5YRPROIBRYeTSKO9DCG5p2vn0eXsVf7s=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "679ac7e772bba1bceff01c0216ac9b33b209b8c3",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1787753358,
+        "narHash": "sha256-Tl77VbWyAKrOfRNQhL6JbQtb/MLzbYa/1RG1gWWfICk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "256551e45f6303e142ab4a98be1bf243feb77dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Siemens AG
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Michael Adler <michael.adler@siemens.com>
+{
+  pkgs,
+  ...
+}:
+
+{
+  packages = [
+    pkgs.git
+    pkgs.just
+    pkgs.fd
+  ];
+
+  env.GOFLAGS = "-tags=testing";
+
+  profiles = {
+    fullstack.extends = [
+      "backend"
+      "frontend"
+      "ci"
+    ];
+
+    backend.module = {
+      packages = [
+        pkgs.goreleaser
+        pkgs.zig
+        pkgs.flatbuffers
+        pkgs.gnumake
+        pkgs.gnused
+
+        pkgs.go
+        pkgs.go-tools
+        pkgs.gofumpt
+        pkgs.gopls
+        pkgs.reftools
+        pkgs.golangci-lint
+      ];
+    };
+
+    frontend.module = {
+      env.GOFLAGS = "-tags=testing,ui";
+      packages = [
+        pkgs.gleam
+        pkgs.beamPackages.rebar3
+        pkgs.beamPackages.erlang
+        pkgs.inotify-tools
+        pkgs.nodejs
+        pkgs.bun
+        pkgs.tailwindcss_4
+
+        pkgs.openssl
+        pkgs.zstd
+      ];
+    };
+
+    pages.module = {
+      packages = [
+        pkgs.hugo
+        pkgs.lychee
+        pkgs.python3
+      ];
+    };
+
+    ci.module = {
+      packages = [
+        pkgs.reuse
+        pkgs.biome
+      ];
+    };
+  };
+
+  enterShell = ''
+    set -a; source .env; set +a
+    ${pkgs.prek}/bin/prek install --overwrite
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+# SPDX-FileCopyrightText: 2026 Siemens AG
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Michael Adler <michael.adler@siemens.com>
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling

--- a/justfile
+++ b/justfile
@@ -3,27 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Author: Michael Adler <michael.adler@siemens.com>
+set dotenv-load
+set dotenv-override
 
 THISDIR := justfile_directory()
 DOCKER := env_var_or_default("DOCKER", "docker")
-NIX := "nix --experimental-features 'nix-command flakes'"
-
-# postgres
-
-export PGUSER := env_var_or_default("PGUSER", "wfx")
-export PGPASSWORD := env_var_or_default("PGPASSWORD", "secret")
-export PGHOST := env_var_or_default("PGHOST", "localhost")
-export PGPORT := env_var_or_default("PGPORT", "5432")
-export PGDATABASE := env_var_or_default("PGDATABASE", "wfx")
-export PGSSLMODE := env_var_or_default("PGSSLMODE", "disable")
-
-# mysql
-
-export MYSQL_USER := env_var_or_default("MYSQL_USER", "root")
-export MYSQL_PASSWORD := env_var_or_default("MYSQL_PASSWORD", "root")
-export MYSQL_ROOT_PASSWORD := env_var_or_default("MYSQL_PASSWORD", "root")
-export MYSQL_DATABASE := env_var_or_default("MYSQL_DATABASE", "wfx")
-export MYSQL_HOST := env_var_or_default("MYSQL_HOST", "localhost")
 
 build:
     env CC={{ THISDIR }}/.ci/zcc goreleaser build --id wfx --id wfxctl --clean --single-target --snapshot
@@ -49,6 +33,7 @@ update-deps:
 pages:
     #!/usr/bin/env bash
     set -euxo pipefail
+    export LUA_PATH="{{ THISDIR }}/hugo/filters/?.lua;;"
     rm -rf public hugo/public
     pushd hugo
     make clean && make -j`nproc`
@@ -62,6 +47,7 @@ pages:
 # Serve docs
 docs-serve:
     #!/bin/sh
+    export LUA_PATH="{{ THISDIR }}/hugo/filters/?.lua;;"
     cd hugo && make clean && make -j`nproc` && hugo server -D
 
 # Lint code

--- a/shell.nix
+++ b/shell.nix
@@ -3,68 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Author: Michael Adler <michael.adler@siemens.com>
-{ pkgs ? import <nixpkgs> { } }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+let
+  # Evaluate devenv.nix without the devenv framework so shell.nix and devenv share a single package list.
+  devenv = import ./devenv.nix {
+    inherit pkgs;
+    lib = pkgs.lib;
+    inputs = { };
+    config.devenv.root = toString ./.;
+  };
+
+  profilePackages = pkgs.lib.flatten (
+    pkgs.lib.mapAttrsToList (
+      _: profile: pkgs.lib.mapAttrsToList (_: module: module.packages or [ ]) profile
+    ) devenv.profiles
+  );
+in
 
 with pkgs;
 
 mkShell {
-  nativeBuildInputs = [
-    (python3.withPackages (ps: with ps; [ pyyaml ]))
-
-    hugo
-
-    sql-formatter
-    biome
-    markdownlint-cli
-    shfmt
-    lychee
-
-    golangci-lint
-    go-tools
-    reuse
-
-    gnumake
-    gnused
-    goreleaser
-    syft
-    zig
-    just
-    git
-    go
-    gopls
-    reftools
-    flatbuffers
-    openssl
-    zstd
-
-    # ui deps
-    gleam
-    beamPackages.rebar3
-    beamPackages.erlang
-    inotify-tools
-    nodejs
-    bun
-    tailwindcss_4
-  ];
-
-  shellHook = ''
-    export GOFLAGS="-tags=sqlite,mysql,postgres,testing,integration,plugin"
-    export LUA_PATH="$(pwd)/hugo/filters/?.lua;;"
-    export PATH="$(pwd):$PATH"
-
-    export CC="$(pwd)/.ci/zcc"
-
-    export PGUSER=wfx \
-           PGPASSWORD=secret\
-           PGHOST=localhost \
-           PGPORT=5432      \
-           PGDATABASE=wfx   \
-           PGSSLMODE=disable
-
-    export MYSQL_USER=root \
-           MYSQL_PASSWORD=root \
-           MYSQL_ROOT_PASSWORD=root \
-           MYSQL_DATABASE=wfx \
-           MYSQL_HOST=localhost
-  '';
+  nativeBuildInputs = devenv.packages ++ profilePackages;
+  shellHook = devenv.enterShell;
 }


### PR DESCRIPTION
### Description

- Introduce devenv environments
- Consolidate nix-shell config with devenv profiles (backwards compatible)
- Use one `.env` file for shared env files
- Split `just build`: main target builds only wfx and wfxctl; build-contrib builds examples/contrib clients.
- Fix `just format` so gofumpt formats only Go files, avoiding ignored and untracked files.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
