### PR TITLE
feat(server)!: make CORS configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking
+
+- CORS is off by default as it is typically not needed to serve the UI (same origin). It can optionally be enabled via the `--cors-enabled` flag.
+- CORS headers will only be set for northbound responses (and never for the southbound API).
+
 ### Added
 
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
-- Configurable CORS headers (`--cors-allowed-origins`, `--cors-allowed-methods`, `--cors-allowed-headers`, `--cors-allow-credentials` and `--cors-max-age` flags)
+- Configurable CORS headers for northbound API
 
 ### Changed
 
@@ -20,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Apply reloaded SSE ping and grace intervals to new job event connections
-- CORS is registered globally now
+- CORS is registered globally now, thereby adding support for the HTTP OPTIONS method
 
 ## [0.6.0] - 2026-06-03
 

--- a/cmd/wfx/cmd/config/appconfig.go
+++ b/cmd/wfx/cmd/config/appconfig.go
@@ -55,11 +55,7 @@ type AppConfig struct {
 	keepAlive      bool
 	cleanupTimeout time.Duration
 
-	corsAllowedOrigins   []string
-	corsAllowedMethods   []string
-	corsAllowedHeaders   []string
-	corsAllowCredentials bool
-	corsMaxAge           time.Duration
+	corsOpts CORSOpts
 
 	tlsCACertificate string
 	tlsCertificate   string
@@ -83,6 +79,15 @@ type AppConfig struct {
 type JQOpts struct {
 	FilterTimeout         time.Duration
 	FilterMaxResponseSize int
+}
+
+type CORSOpts struct {
+	Enabled          bool
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	AllowCredentials bool
+	MaxAge           int
 }
 
 type Scheme int
@@ -240,12 +245,13 @@ func (cfg *AppConfig) Reload() bool {
 	cfg.ssePingInterval = cfg.k.Duration(SSEPingIntervalFlag)
 	cfg.sseGraceInterval = cfg.k.Duration(SSEGraceIntervalFlag)
 
-	cfg.corsAllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
-	cfg.corsAllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
-	cfg.corsAllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
-	cfg.corsAllowCredentials = cfg.k.Bool(CORSAllowCredentialsFlag)
-	cfg.corsMaxAge = cfg.k.Duration(CORSMaxAgeFlag)
-	if cfg.corsAllowCredentials && slices.Contains(cfg.corsAllowedOrigins, "*") {
+	cfg.corsOpts.Enabled = cfg.k.Bool(CORSEnabledFlag)
+	cfg.corsOpts.AllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
+	cfg.corsOpts.AllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
+	cfg.corsOpts.AllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
+	cfg.corsOpts.AllowCredentials = cfg.k.Bool(CORSAllowCredentialsFlag)
+	cfg.corsOpts.MaxAge = int(cfg.k.Duration(CORSMaxAgeFlag) / time.Second)
+	if cfg.corsOpts.AllowCredentials && slices.Contains(cfg.corsOpts.AllowedOrigins, "*") {
 		fmt.Fprintln(os.Stderr, "cors-allow-credentials requires explicit cors-allowed-origins")
 		ok = false
 	}
@@ -460,37 +466,15 @@ func (cfg *AppConfig) SSEGraceInterval() time.Duration {
 	return cfg.sseGraceInterval
 }
 
-func (cfg *AppConfig) CORSAllowedOrigins() []string {
+func (cfg *AppConfig) CORSOpts() CORSOpts {
 	cfg.mutex.RLock()
 	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedOrigins)
-}
 
-func (cfg *AppConfig) CORSAllowedMethods() []string {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedMethods)
-}
-
-func (cfg *AppConfig) CORSAllowedHeaders() []string {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedHeaders)
-}
-
-func (cfg *AppConfig) CORSAllowCredentials() bool {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return cfg.corsAllowCredentials
-}
-
-// CORSMaxAge returns the preflight cache duration in seconds. Zero (the
-// default) omits the Access-Control-Max-Age header; a negative value forces
-// `Access-Control-Max-Age: 0` so browsers stop caching preflights.
-func (cfg *AppConfig) CORSMaxAge() int {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return int(cfg.corsMaxAge / time.Second)
+	opts := cfg.corsOpts
+	opts.AllowedOrigins = slices.Clone(opts.AllowedOrigins)
+	opts.AllowedMethods = slices.Clone(opts.AllowedMethods)
+	opts.AllowedHeaders = slices.Clone(opts.AllowedHeaders)
+	return opts
 }
 
 func (cfg *AppConfig) InitStorage() (persistence.Storage, error) {

--- a/cmd/wfx/cmd/config/flags.go
+++ b/cmd/wfx/cmd/config/flags.go
@@ -61,6 +61,7 @@ const (
 	SSEPingIntervalFlag  = "sse-ping-interval"
 	SSEGraceIntervalFlag = "sse-grace-interval"
 
+	CORSEnabledFlag          = "cors-enabled"
 	CORSAllowedOriginsFlag   = "cors-allowed-origins"
 	CORSAllowedMethodsFlag   = "cors-allowed-methods"
 	CORSAllowedHeadersFlag   = "cors-allowed-headers"
@@ -86,9 +87,6 @@ const (
 	DefaultJQFilterMaxResponseSize = 16 << 20 // 16 MiB
 )
 
-// mirrors the defaults of cors.AllowAll()
-var defaultCORSAllowedMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}
-
 func NewFlagset() *pflag.FlagSet {
 	f := pflag.NewFlagSet("wfx", pflag.ExitOnError)
 
@@ -100,8 +98,9 @@ func NewFlagset() *pflag.FlagSet {
 	f.Duration(SSEPingIntervalFlag, DefaultSSEPingInterval, "interval to send periodic keep-alive messages to prevent server-sent events connections from being closed due to inactivity")
 	f.Duration(SSEGraceIntervalFlag, DefaultSSEGraceInterval, "interval after which non-responsive subscribers are dropped")
 
+	f.Bool(CORSEnabledFlag, false, "add CORS headers to northbound API responses")
 	f.StringSlice(CORSAllowedOriginsFlag, []string{"*"}, "one or multiple origins allowed to make cross-origin requests")
-	f.StringSlice(CORSAllowedMethodsFlag, defaultCORSAllowedMethods, "one or multiple methods allowed when making cross-origin requests")
+	f.StringSlice(CORSAllowedMethodsFlag, strings.Split("GET,HEAD,POST,PUT,PATCH,DELETE", ","), "one or multiple methods allowed when making cross-origin requests")
 	f.StringSlice(CORSAllowedHeadersFlag, []string{"*"}, "one or multiple headers allowed when making cross-origin requests")
 	f.Bool(CORSAllowCredentialsFlag, false, "allow cookies and HTTP authentication to be included in cross-origin requests; requires explicit allowed origins")
 	f.Duration(CORSMaxAgeFlag, 0, "how long the results of preflight requests may be cached by browsers; zero omits the Access-Control-Max-Age header (browsers use their default), a negative value disables preflight caching")

--- a/cmd/wfx/cmd/root/root_test.go
+++ b/cmd/wfx/cmd/root/root_test.go
@@ -65,10 +65,6 @@ func TestUDS(t *testing.T) {
 			time.Sleep(time.Millisecond * 10)
 			continue
 		}
-		defer func() {
-			_ = conn.Close()
-		}()
-
 		req, err := http.NewRequest(http.MethodGet, "/version", nil)
 		require.NoError(t, err)
 		client := &http.Client{
@@ -79,6 +75,10 @@ func TestUDS(t *testing.T) {
 			},
 		}
 		resp, err := client.Do(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		_ = conn.Close()
 		if err == nil && resp.StatusCode == http.StatusOK {
 			break
 		}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,11 +169,12 @@ The following connectivity parameters are available:
 
 ## Cross-Origin Resource Sharing (CORS)
 
-The API servers add CORS headers to responses, allowing browser-based clients to access wfx directly.
-The following parameters control these headers:
+CORS headers are disabled by default and never applied to the southbound API.
+The following parameters control CORS for the northbound API:
 
 | Parameter                  | Description                                                                                                                                                                       |
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cors-enabled`           | Add CORS headers to northbound API responses; disabled by default                                                                                                                  |
 | `--cors-allowed-origins`   | One or multiple origins allowed to make cross-origin requests; defaults to `*` (any origin)                                                                                       |
 | `--cors-allowed-methods`   | One or multiple methods allowed when making cross-origin requests; defaults to `GET,HEAD,POST,PUT,PATCH,DELETE`                                                                   |
 | `--cors-allowed-headers`   | One or multiple headers allowed when making cross-origin requests; defaults to `*` (any header)                                                                                   |
@@ -183,10 +184,10 @@ The following parameters control these headers:
 `--cors-allow-credentials` requires explicit origins. Configuration is rejected if
 `--cors-allowed-origins` contains `*` while credentials are enabled.
 
-For example, to restrict access to a single origin:
+For example, to enable CORS headers:
 
 ```bash
-wfx --cors-allowed-origins https://wfx.example.com
+wfx --cors-enabled --cors-allowed-origins https://wfx-ui.company.cloud
 ```
 
 ## File Server

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -40,9 +40,6 @@ func NewHTTPServer(cfg *config.AppConfig, handler http.Handler) (*http.Server, e
 func configureTLS(server *http.Server, caCert string) error {
 	// Inspired by https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
 	server.TLSConfig = &tls.Config{
-		// Causes servers to use Go's default ciphersuite preferences,
-		// which are tuned to avoid attacks. Does nothing on clients.
-		PreferServerCipherSuites: true,
 		// Only use curves which have assembly implementations
 		// https://github.com/golang/go/tree/master/src/crypto/elliptic
 		CurvePreferences: []tls.CurveID{tls.CurveP256},

--- a/internal/server/job_events_test.go
+++ b/internal/server/job_events_test.go
@@ -37,11 +37,23 @@ func TestJobEventsSubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	north, south := createNorthAndSouth(t, db)
+	corsNorth, _ := createNorthAndSouth(t, db,
+		"--cors-enabled",
+		"--cors-allowed-origins", "https://example.com",
+	)
 
-	handlers := []http.Handler{north, south}
-	for i, name := range allAPIs {
-		handler := handlers[i]
-		t.Run(name, func(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.Handler
+		corsOrigin string
+	}{
+		{name: "north", handler: north},
+		{name: "south", handler: south},
+		{name: "north-cors", handler: corsNorth, corsOrigin: "https://example.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := tc.handler
 			clientID := "TestJobEventsSubscribe"
 
 			var jobID atomic.Pointer[string]
@@ -86,6 +98,7 @@ func TestJobEventsSubscribe(t *testing.T) {
 			rec := sse.NewMockResponseRecorder(t)
 			wg.Go(func() {
 				req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/wfx/v1/jobs/events?ids=%s", *jobID.Load()), nil)
+				req.Header.Set("Origin", "https://example.com")
 				handler.ServeHTTP(rec, req.WithContext(ctx))
 			})
 
@@ -99,13 +112,22 @@ func TestJobEventsSubscribe(t *testing.T) {
 
 			assert.Contains(t, response, "HTTP/1.1 200")
 			assert.Contains(t, response, "Content-Type: text/event-stream")
+			if tc.corsOrigin == "" {
+				assert.NotContains(t, response, "Access-Control-Allow-Origin")
+			} else {
+				assert.Contains(t, response, "Access-Control-Allow-Origin: "+tc.corsOrigin)
+			}
 
 			lines := strings.Split(response, "\r\n")
 			t.Log("HTTP response:")
 			for _, line := range lines {
 				t.Logf(">> %s", line)
 			}
-			assert.Len(t, lines, 8)
+			expectedLines := 7
+			if tc.corsOrigin != "" {
+				expectedLines += 2
+			}
+			assert.Len(t, lines, expectedLines)
 
 			lines = strings.Split(lines[len(lines)-1], "\n")
 

--- a/internal/server/server_collection.go
+++ b/internal/server/server_collection.go
@@ -49,15 +49,6 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	swag, _ := api.GetSpec()
 	validator := nethttpmiddleware.OapiRequestValidatorWithOptions(swag,
 		&nethttpmiddleware.Options{SilenceServersWarning: true})
-	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
-	// route of our mux, so a per-route middleware would never see them.
-	corsMW := cors.New(cors.Options{
-		AllowedOrigins:   cfg.CORSAllowedOrigins(),
-		AllowedMethods:   cfg.CORSAllowedMethods(),
-		AllowedHeaders:   cfg.CORSAllowedHeaders(),
-		AllowCredentials: cfg.CORSAllowCredentials(),
-		MaxAge:           cfg.CORSMaxAge(),
-	}).Handler
 	logMW := logging.NewLoggingMiddleware()
 
 	// LIFO
@@ -82,7 +73,23 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	northServer.Handler = corsMW(northServer.Handler)
+	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
+	// route of our mux, so a per-route middleware would never see them.
+	northHandler := northServer.Handler
+	northServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		corsOpts := cfg.CORSOpts()
+		if !corsOpts.Enabled {
+			northHandler.ServeHTTP(w, r)
+			return
+		}
+		cors.New(cors.Options{
+			AllowedOrigins:   corsOpts.AllowedOrigins,
+			AllowedMethods:   corsOpts.AllowedMethods,
+			AllowedHeaders:   corsOpts.AllowedHeaders,
+			AllowCredentials: corsOpts.AllowCredentials,
+			MaxAge:           corsOpts.MaxAge,
+		}).Handler(northHandler).ServeHTTP(w, r)
+	})
 
 	southPluginMWs, err := createPluginMiddlewares(cfg.ClientPluginsDir())
 	if err != nil {
@@ -100,8 +107,6 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	southServer.Handler = corsMW(southServer.Handler)
-
 	return &ServerCollection{
 		cfg:          cfg,
 		storage:      storage,

--- a/internal/server/server_collection_test.go
+++ b/internal/server/server_collection_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/siemens/wfx/api"
 	"github.com/siemens/wfx/cmd/wfx/cmd/config"
@@ -36,14 +37,115 @@ func TestNewServerCollection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCORSConfigurableOrigins(t *testing.T) {
+func TestCORSNorthboundOnly(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil).Twice()
+	wfx := api.NewWfxServer(dbMock)
+
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name     string
+		handler  http.Handler
+		expected string
+	}{
+		{name: "north", handler: sc.North.Handler, expected: "*"},
+		{name: "south", handler: sc.South.Handler},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+			req.Header.Set("Origin", "https://example.com")
+			tc.handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tc.expected, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSReload(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	cfgFile := path.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: false\n"), 0o600))
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.ConfigFlag, cfgFile}))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	corsOrigin := func(origin string) string {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		sc.North.Handler.ServeHTTP(rec, req)
+		return rec.Header().Get("Access-Control-Allow-Origin")
+	}
+
+	assert.Empty(t, corsOrigin("https://one.example"))
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: true\ncors-allowed-origins: [https://one.example]\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://one.example") == "https://one.example"
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: true\ncors-allowed-origins: [https://two.example]\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://one.example") == "" && corsOrigin("https://two.example") == "https://two.example"
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: false\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://two.example") == ""
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestCORSDisabledByDefault(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSAllowedOriginsFlag, "https://example.com"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse(nil))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSConfigurableOrigins(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil).Twice()
+	wfx := api.NewWfxServer(dbMock)
+
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSAllowedOriginsFlag, "https://example.com",
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -55,16 +157,15 @@ func TestCORSConfigurableOrigins(t *testing.T) {
 		expected string
 	}{
 		{origin: "https://example.com", expected: "https://example.com"},
-		{origin: "https://evil.example.com", expected: ""},
+		{origin: "https://evil.example.com"},
 	} {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
 		req.Header.Set("Origin", tc.origin)
 		sc.North.Handler.ServeHTTP(rec, req)
 
-		result := rec.Result()
-		assert.Equal(t, http.StatusOK, result.StatusCode)
-		assert.Equal(t, tc.expected, result.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, tc.expected, rec.Header().Get("Access-Control-Allow-Origin"))
 	}
 }
 
@@ -72,9 +173,12 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSAllowedMethodsFlag, "GET"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSAllowedMethodsFlag, http.MethodGet,
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -84,14 +188,11 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
-	req.Header.Set("Access-Control-Request-Method", "DELETE")
+	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	// disallowed method in preflight: cors middleware answers without CORS headers,
-	// so the browser rejects the actual request
-	result := rec.Result()
-	assert.Empty(t, result.Header.Get("Access-Control-Allow-Origin"))
-	assert.Empty(t, result.Header.Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Methods"))
 }
 
 func TestCORSAllowCredentials(t *testing.T) {
@@ -99,45 +200,45 @@ func TestCORSAllowCredentials(t *testing.T) {
 	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
 		"--" + config.CORSAllowedOriginsFlag, "https://example.com",
 		"--" + config.CORSAllowCredentialsFlag,
-	})
-	cfg, err := config.NewAppConfig(f)
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
 	sc, err := NewServerCollection(cfg, wfx, dbMock)
 	require.NoError(t, err)
 
-	// actual request
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
 	sc.North.Handler.ServeHTTP(rec, req)
-	result := rec.Result()
-	assert.Equal(t, http.StatusOK, result.StatusCode)
-	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "true", rec.Header().Get("Access-Control-Allow-Credentials"))
 
-	// preflight request
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
 	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
 	sc.North.Handler.ServeHTTP(rec, req)
-	result = rec.Result()
-	assert.Equal(t, http.StatusNoContent, result.StatusCode)
-	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "true", rec.Header().Get("Access-Control-Allow-Credentials"))
 }
 
 func TestCORSMaxAge(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSMaxAgeFlag, "30s"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSMaxAgeFlag, "30s",
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -150,17 +251,16 @@ func TestCORSMaxAge(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	assert.Equal(t, "30", rec.Result().Header.Get("Access-Control-Max-Age"))
+	assert.Equal(t, "30", rec.Header().Get("Access-Control-Max-Age"))
 }
 
 func TestCORSMaxAgeDisabled(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	// default: no --cors-max-age flag, header must be omitted
-	f := config.NewFlagset()
-	_ = f.Parse(nil)
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -173,16 +273,16 @@ func TestCORSMaxAgeDisabled(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	assert.Empty(t, rec.Result().Header.Get("Access-Control-Max-Age"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Max-Age"))
 }
 
-func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
+func TestCORSPreflight(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -196,9 +296,9 @@ func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Headers", "Authorization")
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	result := rec.Result()
-	assert.Equal(t, "*", result.Header.Get("Access-Control-Allow-Origin"))
-	assert.Contains(t, strings.ToLower(result.Header.Get("Access-Control-Allow-Headers")), "authorization")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rec.Header().Get("Access-Control-Allow-Headers"), "Authorization")
 }
 
 func TestCreateServer_UseMiddlewares(t *testing.T) {

--- a/internal/server/workflow_test.go
+++ b/internal/server/workflow_test.go
@@ -235,8 +235,9 @@ func newInMemoryDB(t *testing.T) persistence.Storage {
 	return db
 }
 
-func createNorthAndSouth(t *testing.T, db persistence.Storage) (http.Handler, http.Handler) {
+func createNorthAndSouth(t *testing.T, db persistence.Storage, args ...string) (http.Handler, http.Handler) {
 	flagSet := config.NewFlagset()
+	require.NoError(t, flagSet.Parse(args))
 	cfg, err := config.NewAppConfig(flagSet)
 	require.NoError(t, err)
 

--- a/middleware/sse/responder.go
+++ b/middleware/sse/responder.go
@@ -45,6 +45,13 @@ func NewResponder(ctx context.Context, idleDuration time.Duration, subscriber *e
 func (responder Responder) VisitGetJobsEventsResponse(w http.ResponseWriter) error {
 	log := logging.LoggerFromCtx(responder.ctx).With().Str("subscriberID", responder.subscriber.ID()).Logger()
 
+	// Preserve headers set by middlewares
+	header := w.Header()
+	header.Set("Content-Type", "text/event-stream")
+	header.Set("Cache-Control", "no-cache")
+	header.Set("Connection", "keep-alive")
+	header.Set("X-Accel-Buffering", "no")
+
 	// Check if the ResponseWriter supports hijacking
 	hj, ok := w.(http.Hijacker)
 	if !ok { // e.g. if HTTP/2 is being used
@@ -63,13 +70,10 @@ func (responder Responder) VisitGetJobsEventsResponse(w http.ResponseWriter) err
 	}()
 
 	_, _ = fmt.Fprintf(bufrw, "HTTP/1.1 %d\r\n", http.StatusOK)
-	_, _ = bufrw.WriteString("Content-Type: text/event-stream\r\n")
-	_, _ = bufrw.WriteString("Cache-Control: no-cache\r\n")
-	_, _ = bufrw.WriteString("Connection: keep-alive\r\n")
-	_, _ = bufrw.WriteString("Access-Control-Allow-Origin: *\r\n")
-	_, _ = bufrw.WriteString("X-Accel-Buffering: no\r\n") // notify reverse proxy to disable buffering
-
-	// finish header section
+	// Hijacking bypasses net/http's header write, so include headers manually
+	if err := header.Write(bufrw); err != nil {
+		return fault.Wrap(err)
+	}
 	_, _ = bufrw.WriteString("\r\n")
 
 	if err := bufrw.Flush(); err != nil {

--- a/middleware/sse/responder_test.go
+++ b/middleware/sse/responder_test.go
@@ -43,6 +43,8 @@ func TestResponder(t *testing.T) {
 	})
 
 	rw := NewMockResponseRecorder(t)
+	rw.Header()["Invalid\r\nName"] = []string{"value"}
+	rw.Header().Set("X-Middleware", "safe\r\nInjected: yes")
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -72,6 +74,8 @@ func TestResponder(t *testing.T) {
 	assert.JSONEq(t, expected, string(objJson))
 	assert.Contains(t, resp, "id: 1")
 	assert.Contains(t, resp, "\n\n")
+	assert.NotContains(t, resp, "Invalid")
+	assert.Contains(t, resp, "X-Middleware: safe  Injected: yes\r\n")
 
 	cancel()
 	wg.Wait()


### PR DESCRIPTION
### Description

CORS is now off by default as it is usually not needed to serve the UI (same origin). If CORS is needed, it can be turned on via --cors-enabled. Note that the CORS headers will only be added to northbound API responses as this is the management interface.


#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

#### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [x] My changes adhere to the established code style, patterns, and best practices.
- [x] I have added tests that demonstrate the effectiveness of my changes.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
