### PR TITLE
feat: overhaul wfxctl CLI interface, support for custom headers and auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CORS is off by default as it is typically not needed to serve the UI (same origin). It can optionally be enabled via the `--cors-enabled` flag.
 - CORS headers will only be set for northbound responses (and never for the southbound API).
+- wfxctl now uses a single `--host` parameter defaulting to the northbound API. This replaces the previous separate northbound/southbound host, port, TLS, and Unix socket parameters.
 
 ### Added
 
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
 - Configurable CORS headers for northbound API
-- wfxctl: new global `--client-hdr` and `--mgmt-hdr` flags to add custom HTTP headers to client and management requests, e.g. `--client-hdr 'Authorization: Bearer $TOKEN'` (similar to curl's `-H` option, may be given multiple times)
+- wfxctl: new global `--header` flag to add custom HTTP headers, e.g. `--header 'Authorization: Bearer $TOKEN'` (similar to curl's `-H` option, may be given multiple times)
 - wfxctl: support Git-style credential helper plugins through `--credential-helper`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
 - Configurable CORS headers for northbound API
+- wfxctl: new global `--client-hdr` and `--mgmt-hdr` flags to add custom HTTP headers to client and management requests, e.g. `--client-hdr 'Authorization: Bearer $TOKEN'` (similar to curl's `-H` option, may be given multiple times)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking
+
+- CORS is off by default as it is typically not needed to serve the UI (same origin). It can optionally be enabled via the `--cors-enabled` flag.
+- CORS headers will only be set for northbound responses (and never for the southbound API).
+
 ### Added
 
 - `--jq-filter-timeout` to limit the execution time of JQ response filters (default: 30s, `0` disables the limit)
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
-- Configurable CORS headers (`--cors-allowed-origins`, `--cors-allowed-methods`, `--cors-allowed-headers`, `--cors-allow-credentials` and `--cors-max-age` flags)
+- Configurable CORS headers for northbound API
 
 ### Changed
 
@@ -20,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Apply reloaded SSE ping and grace intervals to new job event connections
-- CORS is registered globally now
+- CORS is registered globally now, thereby adding support for the HTTP OPTIONS method
 
 ## [0.6.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--jq-filter-max-response-size` to limit the size of a JQ response filter result (default: 16 MiB, `0` disables the limit)
 - Configurable CORS headers for northbound API
 - wfxctl: new global `--client-hdr` and `--mgmt-hdr` flags to add custom HTTP headers to client and management requests, e.g. `--client-hdr 'Authorization: Bearer $TOKEN'` (similar to curl's `-H` option, may be given multiple times)
+- wfxctl: support Git-style credential helper plugins through `--credential-helper`
 
 ### Changed
 

--- a/cmd/wfx-loadtest/loadtest/main.go
+++ b/cmd/wfx-loadtest/loadtest/main.go
@@ -11,8 +11,8 @@ package loadtest
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,7 +20,6 @@ import (
 	"github.com/knadh/koanf/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/siemens/wfx/cmd/wfx-loadtest/wfx"
-	"github.com/siemens/wfx/cmd/wfxctl/flags"
 	"github.com/siemens/wfx/generated/api"
 	"github.com/siemens/wfx/workflow/dau"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
@@ -31,9 +30,11 @@ const (
 	// Threshold of data points above which series are downsampled.
 	threshold = 4000
 
-	ReadFreqFlag  = "read-freq"
-	WriteFreqFlag = "write-freq"
-	DurationFlag  = "duration"
+	ClientHostFlag = "client-host"
+	MgmtHostFlag   = "mgmt-host"
+	ReadFreqFlag   = "read-freq"
+	WriteFreqFlag  = "write-freq"
+	DurationFlag   = "duration"
 )
 
 var (
@@ -43,23 +44,19 @@ var (
 	queue      = make([]*api.JobStatus, 0, 10)
 	queueMutex sync.RWMutex
 
-	host     string
-	port     int
-	mgmtHost string
-	mgmtPort int
+	clientHost string
+	mgmtHost   string
 )
 
 func Run(k *koanf.Koanf) error {
-	host = k.String(flags.ClientHostFlag)
-	port = k.Int(flags.ClientPortFlag)
-	mgmtHost = k.String(flags.MgmtHostFlag)
-	mgmtPort = k.Int(flags.MgmtPortFlag)
+	clientHost = strings.TrimRight(k.String(ClientHostFlag), "/")
+	mgmtHost = strings.TrimRight(k.String(MgmtHostFlag), "/")
 
-	if host == "" || mgmtHost == "" {
-		return errors.New("host or mgmtHost not set")
+	if clientHost == "" || mgmtHost == "" {
+		return errors.New("clientHost or mgmtHost not set")
 	}
 
-	if err := wfx.CreateWorkflow(mgmtHost, mgmtPort, *workflow); err != nil {
+	if err := wfx.CreateWorkflow(mgmtHost, *workflow); err != nil {
 		return fault.Wrap(err)
 	}
 
@@ -68,10 +65,8 @@ func Run(k *koanf.Koanf) error {
 	readRate := vegeta.Rate{Freq: k.Int(ReadFreqFlag), Per: time.Second}
 
 	log.Info().
-		Str("host", host).
-		Int("port", port).
+		Str("clientHost", clientHost).
 		Str("mgmtHost", mgmtHost).
-		Int("mgmtPort", mgmtPort).
 		Dur("duration", duration).
 		Int("writeRate", writeRate.Freq).
 		Int("readRate", readRate.Freq).
@@ -85,11 +80,11 @@ func Run(k *koanf.Koanf) error {
 		readTargeter := vegeta.NewStaticTargeter(
 			vegeta.Target{
 				Method: http.MethodGet,
-				URL:    fmt.Sprintf("http://%s:%d/api/wfx/v1/jobs?class=OPEN", host, port),
+				URL:    clientHost + "/api/wfx/v1/jobs?class=OPEN",
 			},
 			vegeta.Target{
 				Method: http.MethodGet,
-				URL:    fmt.Sprintf("http://%s:%d/api/wfx/v1/workflows", host, port),
+				URL:    clientHost + "/api/wfx/v1/workflows",
 			},
 		)
 		attacker := newAttacker()

--- a/cmd/wfx-loadtest/loadtest/write.go
+++ b/cmd/wfx-loadtest/loadtest/write.go
@@ -10,7 +10,6 @@ package loadtest
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync/atomic"
 
@@ -55,11 +54,9 @@ func writeTargeter(tgt *vegeta.Target) error {
 		if to != "" {
 			jobID := (*status.Context)["id"].(string)
 
-			var url string
+			url := mgmtHost + "/api/wfx/v1/jobs/" + jobID + "/status"
 			if eligible == api.CLIENT {
-				url = fmt.Sprintf("http://%s:%d/api/wfx/v1/jobs/%s/status", host, port, jobID)
-			} else {
-				url = fmt.Sprintf("http://%s:%d/api/wfx/v1/jobs/%s/status", mgmtHost, mgmtPort, jobID)
+				url = clientHost + "/api/wfx/v1/jobs/" + jobID + "/status"
 			}
 
 			status.State = to
@@ -105,7 +102,7 @@ func writeTargeter(tgt *vegeta.Target) error {
 	}
 	*tgt = vegeta.Target{
 		Method: http.MethodPost,
-		URL:    fmt.Sprintf("http://%s:%d/api/wfx/v1/jobs", mgmtHost, mgmtPort),
+		URL:    mgmtHost + "/api/wfx/v1/jobs",
 		Body:   b,
 		Header: map[string][]string{
 			"Accept":       {"application/json"},

--- a/cmd/wfx-loadtest/main_test.go
+++ b/cmd/wfx-loadtest/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/cmd/wfx-loadtest/root.go
+++ b/cmd/wfx-loadtest/root.go
@@ -66,10 +66,8 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(populate.NewCommand(k))
 	f := cmd.PersistentFlags()
 
-	f.String(flags.ClientHostFlag, "localhost", "host")
-	f.Int(flags.ClientPortFlag, 8080, "port")
-	f.String(flags.MgmtHostFlag, "localhost", "management host")
-	f.Int(flags.MgmtPortFlag, 8081, "management port")
+	f.String(loadtest.ClientHostFlag, "http://localhost:8080", "client server URL")
+	f.String(loadtest.MgmtHostFlag, "http://localhost:8081", "management server URL")
 
 	f.String(flags.LogLevelFlag, "info", fmt.Sprintf("set log level. one of: %s,%s,%s,%s,%s,%s,%s",
 		zerolog.TraceLevel.String(),

--- a/cmd/wfx-loadtest/root_test.go
+++ b/cmd/wfx-loadtest/root_test.go
@@ -1,0 +1,31 @@
+package main
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootCmd_HostFlags(t *testing.T) {
+	flags := NewCommand().PersistentFlags()
+
+	clientHost := flags.Lookup("client-host")
+	require.NotNil(t, clientHost)
+	assert.Equal(t, "http://localhost:8080", clientHost.DefValue)
+
+	mgmtHost := flags.Lookup("mgmt-host")
+	require.NotNil(t, mgmtHost)
+	assert.Equal(t, "http://localhost:8081", mgmtHost.DefValue)
+
+	assert.Nil(t, flags.Lookup("client-port"))
+	assert.Nil(t, flags.Lookup("mgmt-port"))
+}

--- a/cmd/wfx-loadtest/wfx/workflow.go
+++ b/cmd/wfx-loadtest/wfx/workflow.go
@@ -10,7 +10,6 @@ package wfx
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -20,10 +19,10 @@ import (
 	"github.com/siemens/wfx/generated/api"
 )
 
-func CreateWorkflow(host string, port int, workflow api.Workflow) error {
+func CreateWorkflow(host string, workflow api.Workflow) error {
 	swagger := errutil.Must(api.GetSpec())
 	basePath := errutil.Must(swagger.Servers.BasePath())
-	server := fmt.Sprintf("http://%s:%d%s", host, port, basePath)
+	server := host + basePath
 	log.Info().Str("server", server).Str("name", workflow.Name).Msgf("Creating workflow %q", workflow.Name)
 	client, err := api.NewClientWithResponses(server, api.WithHTTPClient(&http.Client{
 		Timeout: time.Second * 10,

--- a/cmd/wfx/cmd/config/appconfig.go
+++ b/cmd/wfx/cmd/config/appconfig.go
@@ -55,11 +55,7 @@ type AppConfig struct {
 	keepAlive      bool
 	cleanupTimeout time.Duration
 
-	corsAllowedOrigins   []string
-	corsAllowedMethods   []string
-	corsAllowedHeaders   []string
-	corsAllowCredentials bool
-	corsMaxAge           time.Duration
+	corsOpts CORSOpts
 
 	tlsCACertificate string
 	tlsCertificate   string
@@ -83,6 +79,15 @@ type AppConfig struct {
 type JQOpts struct {
 	FilterTimeout         time.Duration
 	FilterMaxResponseSize int
+}
+
+type CORSOpts struct {
+	Enabled          bool
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	AllowCredentials bool
+	MaxAge           int
 }
 
 type Scheme int
@@ -240,12 +245,13 @@ func (cfg *AppConfig) Reload() bool {
 	cfg.ssePingInterval = cfg.k.Duration(SSEPingIntervalFlag)
 	cfg.sseGraceInterval = cfg.k.Duration(SSEGraceIntervalFlag)
 
-	cfg.corsAllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
-	cfg.corsAllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
-	cfg.corsAllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
-	cfg.corsAllowCredentials = cfg.k.Bool(CORSAllowCredentialsFlag)
-	cfg.corsMaxAge = cfg.k.Duration(CORSMaxAgeFlag)
-	if cfg.corsAllowCredentials && slices.Contains(cfg.corsAllowedOrigins, "*") {
+	cfg.corsOpts.Enabled = cfg.k.Bool(CORSEnabledFlag)
+	cfg.corsOpts.AllowedOrigins = cfg.k.Strings(CORSAllowedOriginsFlag)
+	cfg.corsOpts.AllowedMethods = cfg.k.Strings(CORSAllowedMethodsFlag)
+	cfg.corsOpts.AllowedHeaders = cfg.k.Strings(CORSAllowedHeadersFlag)
+	cfg.corsOpts.AllowCredentials = cfg.k.Bool(CORSAllowCredentialsFlag)
+	cfg.corsOpts.MaxAge = int(cfg.k.Duration(CORSMaxAgeFlag) / time.Second)
+	if cfg.corsOpts.AllowCredentials && slices.Contains(cfg.corsOpts.AllowedOrigins, "*") {
 		fmt.Fprintln(os.Stderr, "cors-allow-credentials requires explicit cors-allowed-origins")
 		ok = false
 	}
@@ -460,37 +466,15 @@ func (cfg *AppConfig) SSEGraceInterval() time.Duration {
 	return cfg.sseGraceInterval
 }
 
-func (cfg *AppConfig) CORSAllowedOrigins() []string {
+func (cfg *AppConfig) CORSOpts() CORSOpts {
 	cfg.mutex.RLock()
 	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedOrigins)
-}
 
-func (cfg *AppConfig) CORSAllowedMethods() []string {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedMethods)
-}
-
-func (cfg *AppConfig) CORSAllowedHeaders() []string {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return slices.Clone(cfg.corsAllowedHeaders)
-}
-
-func (cfg *AppConfig) CORSAllowCredentials() bool {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return cfg.corsAllowCredentials
-}
-
-// CORSMaxAge returns the preflight cache duration in seconds. Zero (the
-// default) omits the Access-Control-Max-Age header; a negative value forces
-// `Access-Control-Max-Age: 0` so browsers stop caching preflights.
-func (cfg *AppConfig) CORSMaxAge() int {
-	cfg.mutex.RLock()
-	defer cfg.mutex.RUnlock()
-	return int(cfg.corsMaxAge / time.Second)
+	opts := cfg.corsOpts
+	opts.AllowedOrigins = slices.Clone(opts.AllowedOrigins)
+	opts.AllowedMethods = slices.Clone(opts.AllowedMethods)
+	opts.AllowedHeaders = slices.Clone(opts.AllowedHeaders)
+	return opts
 }
 
 func (cfg *AppConfig) InitStorage() (persistence.Storage, error) {

--- a/cmd/wfx/cmd/config/flags.go
+++ b/cmd/wfx/cmd/config/flags.go
@@ -61,6 +61,7 @@ const (
 	SSEPingIntervalFlag  = "sse-ping-interval"
 	SSEGraceIntervalFlag = "sse-grace-interval"
 
+	CORSEnabledFlag          = "cors-enabled"
 	CORSAllowedOriginsFlag   = "cors-allowed-origins"
 	CORSAllowedMethodsFlag   = "cors-allowed-methods"
 	CORSAllowedHeadersFlag   = "cors-allowed-headers"
@@ -86,9 +87,6 @@ const (
 	DefaultJQFilterMaxResponseSize = 16 << 20 // 16 MiB
 )
 
-// mirrors the defaults of cors.AllowAll()
-var defaultCORSAllowedMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}
-
 func NewFlagset() *pflag.FlagSet {
 	f := pflag.NewFlagSet("wfx", pflag.ExitOnError)
 
@@ -100,8 +98,9 @@ func NewFlagset() *pflag.FlagSet {
 	f.Duration(SSEPingIntervalFlag, DefaultSSEPingInterval, "interval to send periodic keep-alive messages to prevent server-sent events connections from being closed due to inactivity")
 	f.Duration(SSEGraceIntervalFlag, DefaultSSEGraceInterval, "interval after which non-responsive subscribers are dropped")
 
+	f.Bool(CORSEnabledFlag, false, "add CORS headers to northbound API responses")
 	f.StringSlice(CORSAllowedOriginsFlag, []string{"*"}, "one or multiple origins allowed to make cross-origin requests")
-	f.StringSlice(CORSAllowedMethodsFlag, defaultCORSAllowedMethods, "one or multiple methods allowed when making cross-origin requests")
+	f.StringSlice(CORSAllowedMethodsFlag, strings.Split("GET,HEAD,POST,PUT,PATCH,DELETE", ","), "one or multiple methods allowed when making cross-origin requests")
 	f.StringSlice(CORSAllowedHeadersFlag, []string{"*"}, "one or multiple headers allowed when making cross-origin requests")
 	f.Bool(CORSAllowCredentialsFlag, false, "allow cookies and HTTP authentication to be included in cross-origin requests; requires explicit allowed origins")
 	f.Duration(CORSMaxAgeFlag, 0, "how long the results of preflight requests may be cached by browsers; zero omits the Access-Control-Max-Age header (browsers use their default), a negative value disables preflight caching")

--- a/cmd/wfx/cmd/root/root_test.go
+++ b/cmd/wfx/cmd/root/root_test.go
@@ -65,10 +65,6 @@ func TestUDS(t *testing.T) {
 			time.Sleep(time.Millisecond * 10)
 			continue
 		}
-		defer func() {
-			_ = conn.Close()
-		}()
-
 		req, err := http.NewRequest(http.MethodGet, "/version", nil)
 		require.NoError(t, err)
 		client := &http.Client{
@@ -79,6 +75,10 @@ func TestUDS(t *testing.T) {
 			},
 		}
 		resp, err := client.Do(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		_ = conn.Close()
 		if err == nil && resp.StatusCode == http.StatusOK {
 			break
 		}

--- a/cmd/wfxctl/cmd/health/health.go
+++ b/cmd/wfxctl/cmd/health/health.go
@@ -13,16 +13,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
 
 	"github.com/Southclaws/fault"
 	"github.com/gookit/color"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
-	"github.com/siemens/wfx/cmd/wfxctl/errutil"
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
-	"github.com/siemens/wfx/cmd/wfxctl/httpclient"
 	"github.com/siemens/wfx/generated/api"
 )
 
@@ -30,7 +27,6 @@ type Endpoint struct {
 	Name     string
 	Server   string
 	Response *api.GetHealthResponse
-	Editor   api.RequestEditorFn
 }
 
 const (
@@ -60,58 +56,23 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("unsupported color mode: %s", b.ColorMode)
 			}
 
-			swagger := errutil.Must(api.GetSpec())
-			basePath := errutil.Must(swagger.Servers.BasePath())
-			clientEditor, err := httpclient.RequestEditor(b.ClientHdrs, b.CredentialHelper)
+			endpoint := Endpoint{
+				Name:     "wfx",
+				Server:   b.ServerRedacted(),
+				Response: &api.GetHealthResponse{Body: []byte("{}")},
+			}
+			client, err := b.CreateClientWithResponses()
 			if err != nil {
 				return fault.Wrap(err)
 			}
-			mgmtEditor, err := httpclient.RequestEditor(b.MgmtHdrs, b.CredentialHelper)
+			endpoint.Response, err = client.GetHealthWithResponse(cmd.Context())
+			prettyReport(cmd.OutOrStdout(), useColor, endpoint)
 			if err != nil {
 				return fault.Wrap(err)
 			}
-
-			allEndpoints := []Endpoint{
-				{
-					Name:     "northbound",
-					Server:   fmt.Sprintf("http://%s:%d%s", b.MgmtHost, b.MgmtPort, basePath),
-					Response: &api.GetHealthResponse{Body: []byte("{}")},
-					Editor:   mgmtEditor,
-				},
-				{
-					Name:     "southbound",
-					Server:   fmt.Sprintf("http://%s:%d%s", b.Host, b.Port, basePath),
-					Response: &api.GetHealthResponse{Body: []byte("{}")},
-					Editor:   clientEditor,
-				},
-				{
-					Name:     "northbound_tls",
-					Server:   fmt.Sprintf("https://%s:%d%s", b.MgmtTLSHost, b.MgmtTLSPort, basePath),
-					Response: &api.GetHealthResponse{Body: []byte("{}")},
-					Editor:   mgmtEditor,
-				},
-				{
-					Name:     "southbound_tls",
-					Server:   fmt.Sprintf("https://%s:%d%s", b.TLSHost, b.TLSPort, basePath),
-					Response: &api.GetHealthResponse{Body: []byte("{}")},
-					Editor:   clientEditor,
-				},
+			if endpoint.Response.JSON200 == nil || endpoint.Response.JSON200.Status != api.Up {
+				return fmt.Errorf("wfx is not healthy")
 			}
-
-			httpClient, err := b.CreateHTTPClient()
-			if err != nil {
-				return fault.Wrap(err)
-			}
-			var g sync.WaitGroup
-			for i, endpoint := range allEndpoints {
-				g.Go(func() {
-					client := errutil.Must(api.NewClientWithResponses(endpoint.Server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(endpoint.Editor)))
-					resp, _ := client.GetHealthWithResponse(cmd.Context())
-					allEndpoints[i].Response = resp
-				})
-			}
-			g.Wait()
-			prettyReport(cmd.OutOrStdout(), useColor, allEndpoints)
 			return nil
 		},
 	}
@@ -120,31 +81,29 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func prettyReport(w io.Writer, useColor bool, allEndpoints []Endpoint) {
+func prettyReport(w io.Writer, useColor bool, ep Endpoint) {
 	buf := bufio.NewWriter(w)
 	defer func() { _ = buf.Flush() }()
 	_, _ = buf.WriteString("Health report:\n\n")
-	for _, ep := range allEndpoints {
-		status := api.Down
-		if resp := ep.Response; resp != nil {
-			if resp.JSON200 != nil {
-				status = resp.JSON200.Status
-			} else if resp.JSON503 != nil {
-				status = resp.JSON503.Status
-			}
+	status := api.Down
+	if resp := ep.Response; resp != nil {
+		if resp.JSON200 != nil {
+			status = resp.JSON200.Status
+		} else if resp.JSON503 != nil {
+			status = resp.JSON503.Status
 		}
-
-		formatter := fmt.Sprint
-		if useColor {
-			switch status {
-			case api.Up:
-				formatter = color.FgGreen.Render
-			case api.Down:
-				formatter = color.FgRed.Render
-			default:
-				formatter = color.FgYellow.Render
-			}
-		}
-		fmt.Fprintf(buf, "%s\t%s\t(%s)\n", ep.Name, formatter(status), ep.Server)
 	}
+
+	formatter := fmt.Sprint
+	if useColor {
+		switch status {
+		case api.Up:
+			formatter = color.FgGreen.Render
+		case api.Down:
+			formatter = color.FgRed.Render
+		default:
+			formatter = color.FgYellow.Render
+		}
+	}
+	fmt.Fprintf(buf, "%s\t%s\t(%s)\n", ep.Name, formatter(status), ep.Server)
 }

--- a/cmd/wfxctl/cmd/health/health.go
+++ b/cmd/wfxctl/cmd/health/health.go
@@ -62,11 +62,11 @@ func NewCommand() *cobra.Command {
 
 			swagger := errutil.Must(api.GetSpec())
 			basePath := errutil.Must(swagger.Servers.BasePath())
-			clientEditor, err := httpclient.RequestEditor(b.ClientHdrs)
+			clientEditor, err := httpclient.RequestEditor(b.ClientHdrs, b.CredentialHelper)
 			if err != nil {
 				return fault.Wrap(err)
 			}
-			mgmtEditor, err := httpclient.RequestEditor(b.MgmtHdrs)
+			mgmtEditor, err := httpclient.RequestEditor(b.MgmtHdrs, b.CredentialHelper)
 			if err != nil {
 				return fault.Wrap(err)
 			}

--- a/cmd/wfxctl/cmd/health/health.go
+++ b/cmd/wfxctl/cmd/health/health.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/siemens/wfx/cmd/wfxctl/errutil"
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
+	"github.com/siemens/wfx/cmd/wfxctl/httpclient"
 	"github.com/siemens/wfx/generated/api"
 )
 
@@ -29,6 +30,7 @@ type Endpoint struct {
 	Name     string
 	Server   string
 	Response *api.GetHealthResponse
+	Editor   api.RequestEditorFn
 }
 
 const (
@@ -60,27 +62,39 @@ func NewCommand() *cobra.Command {
 
 			swagger := errutil.Must(api.GetSpec())
 			basePath := errutil.Must(swagger.Servers.BasePath())
+			clientEditor, err := httpclient.RequestEditor(b.ClientHdrs)
+			if err != nil {
+				return fault.Wrap(err)
+			}
+			mgmtEditor, err := httpclient.RequestEditor(b.MgmtHdrs)
+			if err != nil {
+				return fault.Wrap(err)
+			}
 
 			allEndpoints := []Endpoint{
 				{
 					Name:     "northbound",
 					Server:   fmt.Sprintf("http://%s:%d%s", b.MgmtHost, b.MgmtPort, basePath),
 					Response: &api.GetHealthResponse{Body: []byte("{}")},
+					Editor:   mgmtEditor,
 				},
 				{
 					Name:     "southbound",
 					Server:   fmt.Sprintf("http://%s:%d%s", b.Host, b.Port, basePath),
 					Response: &api.GetHealthResponse{Body: []byte("{}")},
+					Editor:   clientEditor,
 				},
 				{
 					Name:     "northbound_tls",
 					Server:   fmt.Sprintf("https://%s:%d%s", b.MgmtTLSHost, b.MgmtTLSPort, basePath),
 					Response: &api.GetHealthResponse{Body: []byte("{}")},
+					Editor:   mgmtEditor,
 				},
 				{
 					Name:     "southbound_tls",
 					Server:   fmt.Sprintf("https://%s:%d%s", b.TLSHost, b.TLSPort, basePath),
 					Response: &api.GetHealthResponse{Body: []byte("{}")},
+					Editor:   clientEditor,
 				},
 			}
 
@@ -88,16 +102,13 @@ func NewCommand() *cobra.Command {
 			if err != nil {
 				return fault.Wrap(err)
 			}
-
 			var g sync.WaitGroup
 			for i, endpoint := range allEndpoints {
-				g.Add(1)
-				go func() {
-					defer g.Done()
-					client := errutil.Must(api.NewClientWithResponses(endpoint.Server, api.WithHTTPClient(httpClient)))
+				g.Go(func() {
+					client := errutil.Must(api.NewClientWithResponses(endpoint.Server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(endpoint.Editor)))
 					resp, _ := client.GetHealthWithResponse(cmd.Context())
 					allEndpoints[i].Response = resp
-				}()
+				})
 			}
 			g.Wait()
 			prettyReport(cmd.OutOrStdout(), useColor, allEndpoints)

--- a/cmd/wfxctl/cmd/health/health_test.go
+++ b/cmd/wfxctl/cmd/health/health_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -22,10 +21,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCommand(t *testing.T) {
+func TestNewCommand_Down(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(api.CheckerResult{Status: api.Down})
+	}))
+	defer ts.Close()
+	t.Setenv("WFX_HOST", ts.URL)
+
 	cmd := NewCommand()
 	err := cmd.Execute()
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "wfx is not healthy")
+}
+
+func TestNewCommand_RequestError(t *testing.T) {
+	ts := httptest.NewServer(nil)
+	ts.Close()
+	t.Setenv("WFX_HOST", ts.URL)
+
+	cmd := NewCommand()
+	require.Error(t, cmd.Execute())
 }
 
 func TestNewCommand_Up(t *testing.T) {
@@ -35,18 +51,11 @@ func TestNewCommand_Up(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		response := api.GetHealth200JSONResponse{
-			Body: api.CheckerResult{
-				Status: api.Up,
-			},
-		}
-		_ = json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(api.CheckerResult{Status: api.Up})
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	err := cmd.Execute()
@@ -55,43 +64,54 @@ func TestNewCommand_Up(t *testing.T) {
 }
 
 func TestNewCommand_Headers(t *testing.T) {
-	requests := make(chan *http.Request, 4)
+	var actualHeader string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests <- r
+		actualHeader = r.Header.Get("X-Custom")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"body":{"status":"up"}}`))
+		_, _ = w.Write([]byte(`{"status":"up"}`))
 	}))
 	defer ts.Close()
 
-	u, err := url.Parse(ts.URL)
-	require.NoError(t, err)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
-	cmd.Flags().StringArray(flags.ClientHeaderFlag, nil, "")
-	cmd.Flags().StringArray(flags.MgmtHeaderFlag, nil, "")
-	cmd.SetArgs([]string{"--client-hdr", "X-Client: custom", "--mgmt-hdr", "X-Mgmt: custom"})
+	cmd.Flags().StringArray(flags.HeaderFlag, nil, "")
+	cmd.SetArgs([]string{"--header", "X-Custom: value"})
 	require.NoError(t, cmd.Execute())
 
-	seenClient, seenMgmt := false, false
-	for range 2 {
-		req := <-requests
-		if req.Header.Get("X-Client") != "" {
-			assert.Empty(t, req.Header.Get("X-Mgmt"))
-			seenClient = true
-		} else {
-			assert.Equal(t, "custom", req.Header.Get("X-Mgmt"))
-			seenMgmt = true
-		}
-	}
-	assert.True(t, seenClient)
-	assert.True(t, seenMgmt)
+	assert.Equal(t, "value", actualHeader)
+}
+
+func TestNewCommand_HidesBasicAuth(t *testing.T) {
+	var authorization string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"up"}`))
+	}))
+	defer ts.Close()
+
+	host := "http://user:secret@" + ts.Listener.Addr().String()
+	t.Setenv("WFX_HOST", host)
+	var output bytes.Buffer
+	cmd := NewCommand()
+	cmd.SetOut(&output)
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "Basic dXNlcjpzZWNyZXQ=", authorization)
+	assert.NotContains(t, output.String(), "user")
+	assert.NotContains(t, output.String(), "secret")
+	assert.Contains(t, output.String(), ts.Listener.Addr().String())
 }
 
 func TestNewCommand_ColorModes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.CheckerResult{Status: api.Up})
+	}))
+	defer ts.Close()
+	t.Setenv("WFX_HOST", ts.URL)
+
 	for _, mode := range []string{colorAlways, colorAuto, colorNever} {
 		cmd := NewCommand()
 		cmd.SetArgs([]string{"--color", mode})
@@ -106,21 +126,20 @@ func TestNewCommand_ColorModes(t *testing.T) {
 
 func TestPrettyReport_Empty(t *testing.T) {
 	buf := new(bytes.Buffer)
-	prettyReport(buf, false, nil)
-	prettyReport(buf, true, nil)
+	prettyReport(buf, false, Endpoint{})
+	prettyReport(buf, true, Endpoint{})
 	assert.NotEmpty(t, buf)
 }
 
 func TestPrettyReport(t *testing.T) {
-	buf := new(bytes.Buffer)
-
-	allEndpoints := []Endpoint{
+	for _, endpoint := range []Endpoint{
 		{Name: "Foo", Server: "http://127.0.0.1", Response: &api.GetHealthResponse{JSON200: &api.CheckerResult{Status: api.Up}}},
 		{Name: "Foo", Server: "http://127.0.0.2", Response: &api.GetHealthResponse{JSON503: &api.CheckerResult{Status: api.Down}}},
 		{Name: "Foo", Server: "http://127.0.0.3", Response: &api.GetHealthResponse{JSON503: &api.CheckerResult{Status: api.Unknown}}},
+	} {
+		buf := new(bytes.Buffer)
+		prettyReport(buf, false, endpoint)
+		prettyReport(buf, true, endpoint)
+		assert.NotEmpty(t, buf)
 	}
-
-	prettyReport(buf, false, allEndpoints)
-	prettyReport(buf, true, allEndpoints)
-	assert.NotEmpty(t, buf)
 }

--- a/cmd/wfxctl/cmd/health/health_test.go
+++ b/cmd/wfxctl/cmd/health/health_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/siemens/wfx/cmd/wfxctl/flags"
 	"github.com/siemens/wfx/generated/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,43 @@ func TestNewCommand_Up(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	assert.Equal(t, "/api/wfx/v1/health", actualPath)
+}
+
+func TestNewCommand_Headers(t *testing.T) {
+	requests := make(chan *http.Request, 4)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"body":{"status":"up"}}`))
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
+	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_MGMT_HOST", u.Hostname())
+	t.Setenv("WFX_MGMT_PORT", u.Port())
+
+	cmd := NewCommand()
+	cmd.Flags().StringArray(flags.ClientHeaderFlag, nil, "")
+	cmd.Flags().StringArray(flags.MgmtHeaderFlag, nil, "")
+	cmd.SetArgs([]string{"--client-hdr", "X-Client: custom", "--mgmt-hdr", "X-Mgmt: custom"})
+	require.NoError(t, cmd.Execute())
+
+	seenClient, seenMgmt := false, false
+	for range 2 {
+		req := <-requests
+		if req.Header.Get("X-Client") != "" {
+			assert.Empty(t, req.Header.Get("X-Mgmt"))
+			seenClient = true
+		} else {
+			assert.Equal(t, "custom", req.Header.Get("X-Mgmt"))
+			seenMgmt = true
+		}
+	}
+	assert.True(t, seenClient)
+	assert.True(t, seenMgmt)
 }
 
 func TestNewCommand_ColorModes(t *testing.T) {

--- a/cmd/wfxctl/cmd/job/addtags/add_tags.go
+++ b/cmd/wfxctl/cmd/job/addtags/add_tags.go
@@ -27,7 +27,7 @@ func NewCommand() *cobra.Command {
 			baseCmd := flags.NewBaseCmd(cmd.Flags())
 			tags := args
 
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.PostJobsIdTags(cmd.Context(), baseCmd.ID, nil, api.PostJobsIdTagsJSONRequestBody(tags))
 			if err != nil {
 				return fault.Wrap(err)

--- a/cmd/wfxctl/cmd/job/addtags/add_tags_test.go
+++ b/cmd/wfxctl/cmd/job/addtags/add_tags_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -35,9 +34,7 @@ func TestAddTags(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{

--- a/cmd/wfxctl/cmd/job/create/create.go
+++ b/cmd/wfxctl/cmd/job/create/create.go
@@ -74,7 +74,7 @@ echo '{ "title": "Task 1" }' | wfxctl job create --client-id=my_client --workflo
 				return errors.New("Too many arguments")
 			}
 
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.PostJobs(cmd.Context(), nil, request)
 			if err != nil {
 				return fault.Wrap(err)

--- a/cmd/wfxctl/cmd/job/create/create_test.go
+++ b/cmd/wfxctl/cmd/job/create/create_test.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -46,9 +45,7 @@ func TestCreateJob(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	var stdin bytes.Buffer
 	stdin.Write([]byte(data))

--- a/cmd/wfxctl/cmd/job/delete/delete.go
+++ b/cmd/wfxctl/cmd/job/delete/delete.go
@@ -25,7 +25,7 @@ func NewCommand() *cobra.Command {
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			baseCmd := flags.NewBaseCmd(cmd.Flags())
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.DeleteJobsId(cmd.Context(), baseCmd.ID)
 			if err != nil {
 				return fault.Wrap(err)

--- a/cmd/wfxctl/cmd/job/delete/delete_test.go
+++ b/cmd/wfxctl/cmd/job/delete/delete_test.go
@@ -11,7 +11,6 @@ package delete
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,9 +28,7 @@ func TestCreateJob(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--id=1"})

--- a/cmd/wfxctl/cmd/job/deltags/del_tags.go
+++ b/cmd/wfxctl/cmd/job/deltags/del_tags.go
@@ -32,7 +32,7 @@ func NewCommand() *cobra.Command {
 			baseCmd := flags.NewBaseCmd(cmd.Flags())
 			tags := args
 
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.DeleteJobsIdTags(cmd.Context(), baseCmd.ID, nil, api.DeleteJobsIdTagsJSONRequestBody(tags))
 			if err != nil {
 				return fault.Wrap(err)

--- a/cmd/wfxctl/cmd/job/deltags/del_tags_test.go
+++ b/cmd/wfxctl/cmd/job/deltags/del_tags_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -34,9 +33,7 @@ func TestDelTags(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.IDFlag, "1", "bar"})

--- a/cmd/wfxctl/cmd/job/events/events.go
+++ b/cmd/wfxctl/cmd/job/events/events.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/siemens/wfx/cmd/wfxctl/errutil"
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
-	"github.com/siemens/wfx/cmd/wfxctl/httpclient"
 	"github.com/siemens/wfx/generated/api"
 )
 
@@ -58,16 +57,10 @@ var validator = func(out io.Writer) sse.ResponseValidator {
 type SSETransport struct {
 	sseClient *sse.Client
 	out       io.Writer
-	editors   []api.RequestEditorFn
 }
 
 // Do implements the runtime.ClientTransport interface.
 func (t SSETransport) Do(req *http.Request) (*http.Response, error) {
-	for _, editor := range t.editors {
-		if err := editor(req.Context(), req); err != nil {
-			return nil, fault.Wrap(err)
-		}
-	}
 	conn := t.sseClient.NewConnection(req)
 	unsubscribe := conn.SubscribeMessages(func(event sse.Event) {
 		_, _ = t.out.Write([]byte(event.Data))
@@ -111,22 +104,9 @@ wfxctl job events --job-id=1 --job-id=2 --client-id=foo
 			sseClient.OnRetry = func(_ error, sleep time.Duration) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "SSE connection lost. Attempting to reconnect in %v...\n", sleep)
 			}
-			editor, err := httpclient.RequestEditor(baseCmd.ClientHdrs, baseCmd.CredentialHelper)
-			if err != nil {
-				return fault.Wrap(err)
-			}
-			transport := SSETransport{sseClient: sse.DefaultClient, out: cmd.OutOrStdout(), editors: []api.RequestEditorFn{editor}}
+			transport := SSETransport{sseClient: sse.DefaultClient, out: cmd.OutOrStdout()}
 
-			var server string
-			swagger := errutil.Must(api.GetSpec())
-			basePath := errutil.Must(swagger.Servers.BasePath())
-			if baseCmd.EnableTLS {
-				server = fmt.Sprintf("https://%s:%d%s", baseCmd.TLSHost, baseCmd.TLSPort, basePath)
-			} else {
-				server = fmt.Sprintf("http://%s:%d%s", baseCmd.Host, baseCmd.Port, basePath)
-			}
-
-			client, err := api.NewClient(server, api.WithHTTPClient(transport))
+			client, err := baseCmd.CreateClient(api.WithHTTPClient(transport))
 			if err != nil {
 				return fault.Wrap(err)
 			}

--- a/cmd/wfxctl/cmd/job/events/events.go
+++ b/cmd/wfxctl/cmd/job/events/events.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/siemens/wfx/cmd/wfxctl/errutil"
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
+	"github.com/siemens/wfx/cmd/wfxctl/httpclient"
 	"github.com/siemens/wfx/generated/api"
 )
 
@@ -57,10 +58,16 @@ var validator = func(out io.Writer) sse.ResponseValidator {
 type SSETransport struct {
 	sseClient *sse.Client
 	out       io.Writer
+	editors   []api.RequestEditorFn
 }
 
 // Do implements the runtime.ClientTransport interface.
 func (t SSETransport) Do(req *http.Request) (*http.Response, error) {
+	for _, editor := range t.editors {
+		if err := editor(req.Context(), req); err != nil {
+			return nil, fault.Wrap(err)
+		}
+	}
 	conn := t.sseClient.NewConnection(req)
 	unsubscribe := conn.SubscribeMessages(func(event sse.Event) {
 		_, _ = t.out.Write([]byte(event.Data))
@@ -104,7 +111,11 @@ wfxctl job events --job-id=1 --job-id=2 --client-id=foo
 			sseClient.OnRetry = func(_ error, sleep time.Duration) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "SSE connection lost. Attempting to reconnect in %v...\n", sleep)
 			}
-			transport := SSETransport{sseClient: sse.DefaultClient, out: cmd.OutOrStdout()}
+			editor, err := httpclient.RequestEditor(baseCmd.ClientHdrs)
+			if err != nil {
+				return fault.Wrap(err)
+			}
+			transport := SSETransport{sseClient: sse.DefaultClient, out: cmd.OutOrStdout(), editors: []api.RequestEditorFn{editor}}
 
 			var server string
 			swagger := errutil.Must(api.GetSpec())

--- a/cmd/wfxctl/cmd/job/events/events.go
+++ b/cmd/wfxctl/cmd/job/events/events.go
@@ -111,7 +111,7 @@ wfxctl job events --job-id=1 --job-id=2 --client-id=foo
 			sseClient.OnRetry = func(_ error, sleep time.Duration) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "SSE connection lost. Attempting to reconnect in %v...\n", sleep)
 			}
-			editor, err := httpclient.RequestEditor(baseCmd.ClientHdrs)
+			editor, err := httpclient.RequestEditor(baseCmd.ClientHdrs, baseCmd.CredentialHelper)
 			if err != nil {
 				return fault.Wrap(err)
 			}

--- a/cmd/wfxctl/cmd/job/events/events_test.go
+++ b/cmd/wfxctl/cmd/job/events/events_test.go
@@ -45,6 +45,27 @@ func TestSubscribeJobStatus(t *testing.T) {
 	assert.Equal(t, expectedPath, actualPath)
 }
 
+func TestSubscribeJobStatusHeaders(t *testing.T) {
+	var actualHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualHeader = r.Header.Get("X-Custom")
+		w.Header().Add("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.Close)
+
+	u, _ := url.Parse(ts.URL)
+	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
+	t.Setenv("WFX_CLIENT_PORT", u.Port())
+
+	cmd := NewCommand()
+	cmd.Flags().StringArray(flags.ClientHeaderFlag, nil, "")
+	cmd.SetArgs([]string{"--" + flags.ClientHeaderFlag, "X-Custom: value"})
+	err := cmd.Execute()
+	assert.ErrorContains(t, err, "connection to server lost")
+	assert.Equal(t, "value", actualHeader)
+}
+
 func TestValidator_OK(t *testing.T) {
 	out := new(bytes.Buffer)
 	resp := http.Response{StatusCode: http.StatusOK}

--- a/cmd/wfxctl/cmd/job/events/events_test.go
+++ b/cmd/wfxctl/cmd/job/events/events_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -34,9 +33,7 @@ func TestSubscribeJobStatus(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.JobIDFlag, "1"})
@@ -54,13 +51,11 @@ func TestSubscribeJobStatusHeaders(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
-	cmd.Flags().StringArray(flags.ClientHeaderFlag, nil, "")
-	cmd.SetArgs([]string{"--" + flags.ClientHeaderFlag, "X-Custom: value"})
+	cmd.Flags().StringArray(flags.HeaderFlag, nil, "")
+	cmd.SetArgs([]string{"--" + flags.HeaderFlag, "X-Custom: value"})
 	err := cmd.Execute()
 	assert.ErrorContains(t, err, "connection to server lost")
 	assert.Equal(t, "value", actualHeader)

--- a/cmd/wfxctl/cmd/job/get/get_test.go
+++ b/cmd/wfxctl/cmd/job/get/get_test.go
@@ -11,7 +11,6 @@ package get
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -31,9 +30,7 @@ func TestGetJob(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.IDFlag, "1"})

--- a/cmd/wfxctl/cmd/job/getdefinition/get_definition_test.go
+++ b/cmd/wfxctl/cmd/job/getdefinition/get_definition_test.go
@@ -11,7 +11,6 @@ package getdefinition
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -32,9 +31,7 @@ func TestGetJobStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.IDFlag, "1"})

--- a/cmd/wfxctl/cmd/job/getstatus/get_status_test.go
+++ b/cmd/wfxctl/cmd/job/getstatus/get_status_test.go
@@ -11,7 +11,6 @@ package getstatus
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -32,9 +31,7 @@ func TestGetJobStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.IDFlag, "1"})

--- a/cmd/wfxctl/cmd/job/gettags/get_tags_test.go
+++ b/cmd/wfxctl/cmd/job/gettags/get_tags_test.go
@@ -11,7 +11,6 @@ package gettags
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -34,9 +33,7 @@ func TestAddTags(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.IDFlag, "1"})
 	err := cmd.Execute()

--- a/cmd/wfxctl/cmd/job/query/query_test.go
+++ b/cmd/wfxctl/cmd/job/query/query_test.go
@@ -11,7 +11,6 @@ package query
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -39,9 +38,7 @@ func TestQueryJobs(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.ClientIDFlag, "my_client", "--" + flags.GroupFlag, "OPEN", "--" + flags.StateFlag, "DOWNLOAD", "--" + flags.WorkflowFlag, "wfx.workflow.dau.direct"})

--- a/cmd/wfxctl/cmd/job/updatedefinition/update_definition.go
+++ b/cmd/wfxctl/cmd/job/updatedefinition/update_definition.go
@@ -34,7 +34,7 @@ wfxctl job update-definition
 			if id == "" {
 				return errors.New("job id missing")
 			}
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.PutJobsIdDefinitionWithBody(cmd.Context(), id, nil, "application/json", bufio.NewReader(cmd.InOrStdin()))
 			if err != nil {
 				return fault.Wrap(err)

--- a/cmd/wfxctl/cmd/job/updatedefinition/update_definition_test.go
+++ b/cmd/wfxctl/cmd/job/updatedefinition/update_definition_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -35,9 +34,7 @@ func TestUpdateJobDefinition(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	var stdin bytes.Buffer
 	stdin.Write([]byte("{}"))

--- a/cmd/wfxctl/cmd/job/updatestatus/update_status.go
+++ b/cmd/wfxctl/cmd/job/updatestatus/update_status.go
@@ -10,7 +10,6 @@ package updatestatus
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/Southclaws/fault"
 	"github.com/spf13/cobra"
@@ -44,12 +43,7 @@ wfxctl job update-status --id=8ea1e9d7-28e6-4f1f-b444-a8d2d1ad7618 --client-id=c
 				Message:  message,
 			}
 
-			var client *api.Client
-			if strings.ToUpper(baseCmd.Actor) == string(api.CLIENT) {
-				client = errutil.Must(baseCmd.CreateClient())
-			} else {
-				client = errutil.Must(baseCmd.CreateMgmtClient())
-			}
+			client := errutil.Must(baseCmd.CreateClient())
 			resp, err := client.PutJobsIdStatus(cmd.Context(), id, nil, api.PutJobsIdStatusJSONRequestBody(status))
 			if err != nil {
 				return fault.Wrap(err)
@@ -59,7 +53,6 @@ wfxctl job update-status --id=8ea1e9d7-28e6-4f1f-b444-a8d2d1ad7618 --client-id=c
 	}
 	f := cmd.Flags()
 	f.String(flags.IDFlag, "", "job which shall be updated")
-	f.String(flags.ActorFlag, string(api.CLIENT), "actor to use (eligible)")
 	f.String(flags.ClientIDFlag, "", "client which sends the update")
 	f.String(flags.StateFlag, "", "name of the new state")
 	f.Int(flags.ProgressFlag, 0, "progress value (0 <= progress <= 100)")

--- a/cmd/wfxctl/cmd/job/updatestatus/update_status_test.go
+++ b/cmd/wfxctl/cmd/job/updatestatus/update_status_test.go
@@ -12,11 +12,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
-	"github.com/siemens/wfx/generated/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,9 +32,7 @@ func TestUpdateJobStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{
@@ -45,7 +41,6 @@ func TestUpdateJobStatus(t *testing.T) {
 		"--" + flags.ProgressFlag, "42",
 		"--" + flags.StateFlag, "DOWNLOADED",
 		"--" + flags.IDFlag, "1",
-		"--" + flags.ActorFlag, string(api.CLIENT),
 	})
 	err := cmd.Execute()
 	assert.NoError(t, err)

--- a/cmd/wfxctl/cmd/root.go
+++ b/cmd/wfxctl/cmd/root.go
@@ -45,23 +45,10 @@ Tip: Shell completion is available for Bash, Fish and Zsh. See wfxctl completion
 	f.StringSlice(flags.ConfigFlag, config.DefaultConfigFiles(), "path to one or more .yaml config files; if this option is not set, then the default paths are tried")
 	_ = cmd.MarkPersistentFlagFilename(flags.ConfigFlag, "yml", "yaml")
 
-	f.String(flags.ClientHostFlag, "localhost", "host")
-	f.Int(flags.ClientPortFlag, 8080, "port")
-	f.String(flags.ClientTLSHostFlag, "localhost", "TLS host")
-	f.Int(flags.ClientTLSPortFlag, 8443, "TLS port")
-	f.String(flags.ClientUnixSocketFlag, "", "connect via the given unix-domain socket (if set, this overrides http/tls)")
-
-	f.String(flags.MgmtHostFlag, "localhost", "management host")
-	f.Int(flags.MgmtPortFlag, 8081, "management port")
-	f.String(flags.MgmtTLSHostFlag, "localhost", "management TLS host")
-	f.Int(flags.MgmtTLSPortFlag, 8444, "management TLS port")
-	f.String(flags.MgmtUnixSocketFlag, "", "connect via the given unix-domain socket (if set, this overrides http/tls)")
-
+	f.String(flags.HostFlag, "http://localhost:8081", "server URL (http://, https://, or unix:///path/to/socket)")
 	f.String(flags.TLSCaFlag, "", "ca bundle (PEM)")
-	f.Bool(flags.EnableTLSFlag, false, "whether to enable TLS (https)")
 
-	f.StringArray(flags.ClientHeaderFlag, nil, "add an HTTP header to client requests, e.g. --client-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
-	f.StringArray(flags.MgmtHeaderFlag, nil, "add an HTTP header to management requests, e.g. --mgmt-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
+	f.StringArray(flags.HeaderFlag, nil, "add an HTTP header, e.g. --header 'Authorization: Bearer $TOKEN' (may be given multiple times)")
 	f.String(flags.CredentialHelperFlag, "", "credential helper to invoke for HTTP authentication (wfxctl-credential-<name>, or path containing '/')")
 
 	f.String(flags.FilterFlag, "", "output filter (jq-expression). example: '.id'")

--- a/cmd/wfxctl/cmd/root.go
+++ b/cmd/wfxctl/cmd/root.go
@@ -62,6 +62,7 @@ Tip: Shell completion is available for Bash, Fish and Zsh. See wfxctl completion
 
 	f.StringArray(flags.ClientHeaderFlag, nil, "add an HTTP header to client requests, e.g. --client-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
 	f.StringArray(flags.MgmtHeaderFlag, nil, "add an HTTP header to management requests, e.g. --mgmt-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
+	f.String(flags.CredentialHelperFlag, "", "credential helper to invoke for HTTP authentication (wfxctl-credential-<name>, or path containing '/')")
 
 	f.String(flags.FilterFlag, "", "output filter (jq-expression). example: '.id'")
 	f.Bool(flags.RawFlag, false, "output raw strings, not JSON texts; use --filter to select a single entity")

--- a/cmd/wfxctl/cmd/root.go
+++ b/cmd/wfxctl/cmd/root.go
@@ -60,6 +60,9 @@ Tip: Shell completion is available for Bash, Fish and Zsh. See wfxctl completion
 	f.String(flags.TLSCaFlag, "", "ca bundle (PEM)")
 	f.Bool(flags.EnableTLSFlag, false, "whether to enable TLS (https)")
 
+	f.StringArray(flags.ClientHeaderFlag, nil, "add an HTTP header to client requests, e.g. --client-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
+	f.StringArray(flags.MgmtHeaderFlag, nil, "add an HTTP header to management requests, e.g. --mgmt-hdr 'Authorization: Bearer $TOKEN' (may be given multiple times)")
+
 	f.String(flags.FilterFlag, "", "output filter (jq-expression). example: '.id'")
 	f.Bool(flags.RawFlag, false, "output raw strings, not JSON texts; use --filter to select a single entity")
 

--- a/cmd/wfxctl/cmd/root_test.go
+++ b/cmd/wfxctl/cmd/root_test.go
@@ -21,3 +21,18 @@ func TestRootCmd_ManPage(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, cmd)
 }
+
+func TestRootCmd_HostFlag(t *testing.T) {
+	cmd := NewCommand()
+	flag := cmd.PersistentFlags().Lookup("host")
+	require.NotNil(t, flag)
+	assert.Equal(t, "http://localhost:8081", flag.DefValue)
+
+	for _, removed := range []string{
+		"enable-tls",
+		"client-host", "client-port", "client-tls-host", "client-tls-port", "client-unix-socket",
+		"mgmt-host", "mgmt-port", "mgmt-tls-host", "mgmt-tls-port", "mgmt-unix-socket",
+	} {
+		assert.Nil(t, cmd.PersistentFlags().Lookup(removed))
+	}
+}

--- a/cmd/wfxctl/cmd/version/version_test.go
+++ b/cmd/wfxctl/cmd/version/version_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/generated/api"
@@ -38,9 +37,7 @@ func TestVersion(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	err := cmd.Execute()

--- a/cmd/wfxctl/cmd/workflow/create/create.go
+++ b/cmd/wfxctl/cmd/workflow/create/create.go
@@ -73,7 +73,7 @@ EOF
 				return fault.Wrap(err)
 			}
 			log.Info().Int("count", len(allWorkflows)).Msg("Creating workflows")
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			for _, wf := range allWorkflows {
 				resp, err := client.PostWorkflows(cmd.Context(), nil, api.PostWorkflowsJSONRequestBody(wf))
 				if err != nil {

--- a/cmd/wfxctl/cmd/workflow/create/create_test.go
+++ b/cmd/wfxctl/cmd/workflow/create/create_test.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"testing"
 
@@ -35,8 +34,6 @@ func TestCreateWorkflow(t *testing.T) {
 		_, _ = w.Write(b)
 	}))
 	t.Cleanup(ts.Close)
-
-	u, _ := url.Parse(ts.URL)
 
 	tests := []struct {
 		name     string
@@ -69,8 +66,7 @@ func TestCreateWorkflow(t *testing.T) {
 		},
 	}
 
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/wfxctl/cmd/workflow/delete/delete.go
+++ b/cmd/wfxctl/cmd/workflow/delete/delete.go
@@ -24,7 +24,7 @@ func NewCommand() *cobra.Command {
 		Example:          "wfxctl workflow delete wfx.workflow.kanban",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			baseCmd := flags.NewBaseCmd(cmd.Flags())
-			client := errutil.Must(baseCmd.CreateMgmtClient())
+			client := errutil.Must(baseCmd.CreateClient())
 			for _, name := range args {
 				resp, err := client.DeleteWorkflowsName(cmd.Context(), name)
 				if err != nil {

--- a/cmd/wfxctl/cmd/workflow/delete/delete_test.go
+++ b/cmd/wfxctl/cmd/workflow/delete/delete_test.go
@@ -11,7 +11,6 @@ package delete
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,9 +29,7 @@ func TestDeleteWorkflow(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_MGMT_HOST", u.Hostname())
-	t.Setenv("WFX_MGMT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"wfx.workflow.dau.direct"})

--- a/cmd/wfxctl/cmd/workflow/get/get_test.go
+++ b/cmd/wfxctl/cmd/workflow/get/get_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -36,9 +35,7 @@ func TestGetWorkflow(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.NameFlag, "test"})

--- a/cmd/wfxctl/cmd/workflow/query/query_test.go
+++ b/cmd/wfxctl/cmd/workflow/query/query_test.go
@@ -11,7 +11,6 @@ package query
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/siemens/wfx/cmd/wfxctl/flags"
@@ -33,9 +32,7 @@ func TestQueryWorkflows(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	u, _ := url.Parse(ts.URL)
-	t.Setenv("WFX_CLIENT_HOST", u.Hostname())
-	t.Setenv("WFX_CLIENT_PORT", u.Port())
+	t.Setenv("WFX_HOST", ts.URL)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{"--" + flags.OffsetFlag, "0", "--" + flags.LimitFlag, "10"})

--- a/cmd/wfxctl/flags/basecmd.go
+++ b/cmd/wfxctl/flags/basecmd.go
@@ -9,6 +9,7 @@ package flags
  */
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -17,6 +18,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -37,32 +39,20 @@ import (
 )
 
 const (
-	ActorFlag            = "actor"
-	ClientHeaderFlag     = "client-hdr"
-	ClientHostFlag       = "client-host"
 	ClientIDFlag         = "client-id"
-	ClientPortFlag       = "client-port"
-	ClientTLSHostFlag    = "client-tls-host"
-	ClientTLSPortFlag    = "client-tls-port"
-	ClientUnixSocketFlag = "client-unix-socket"
 	ColorFlag            = "color"
 	ConfigFlag           = "config"
 	CredentialHelperFlag = "credential-helper"
-	EnableTLSFlag        = "enable-tls"
 	FilterFlag           = "filter"
 	GroupFlag            = "group"
+	HeaderFlag           = "header"
 	HistoryFlag          = "history"
+	HostFlag             = "host"
 	IDFlag               = "id"
 	JobIDFlag            = "job-id"
 	LimitFlag            = "limit"
 	LogLevelFlag         = "log-level"
 	MessageFlag          = "message"
-	MgmtHeaderFlag       = "mgmt-hdr"
-	MgmtHostFlag         = "mgmt-host"
-	MgmtPortFlag         = "mgmt-port"
-	MgmtTLSHostFlag      = "mgmt-tls-host"
-	MgmtTLSPortFlag      = "mgmt-tls-port"
-	MgmtUnixSocketFlag   = "mgmt-unix-socket"
 	OffsetFlag           = "offset"
 	ProgressFlag         = "progress"
 	RawFlag              = "raw"
@@ -76,46 +66,32 @@ const (
 )
 
 type BaseCmd struct {
-	EnableTLS bool
-	TLSCa     string
+	TLSCa string
 
-	Host    string `validate:"required,hostname_rfc1123"`
-	Port    int    `validate:"required"`
-	TLSHost string `validate:"required,hostname_rfc1123"`
-	TLSPort int    `validate:"required"`
-	Socket  string
-
-	MgmtHost    string `validate:"required,hostname_rfc1123"`
-	MgmtPort    int    `validate:"required"`
-	MgmtTLSHost string `validate:"required,hostname_rfc1123"`
-	MgmtTLSPort int    `validate:"required"`
-	MgmtSocket  string
+	Host string `validate:"required"`
 
 	Filter string
 	// Strip quotes to make output usable in shell scripts
 	RawOutput bool
 	ColorMode string
 
-	ID        string
-	ClientID  string
-	ClientIDs []string
-	Workflow  string
-	Workflows []string
-	Tags      *[]string
-	State     string
-	Sort      string
-	Groups    []string
-	Offset    int64
-	JobIDs    []string
-	History   bool
-	Progress  int
-	Message   string
-	Actor     string
-	Name      string
-	Limit     int32
-
-	ClientHdrs       []string
-	MgmtHdrs         []string
+	ID               string
+	ClientID         string
+	ClientIDs        []string
+	Workflow         string
+	Workflows        []string
+	Tags             *[]string
+	State            string
+	Sort             string
+	Groups           []string
+	Offset           int64
+	JobIDs           []string
+	History          bool
+	Progress         int
+	Message          string
+	Name             string
+	Limit            int32
+	Headers          []string
 	CredentialHelper string
 }
 
@@ -146,8 +122,8 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 		TransformFunc: func(k string, v string) (string, any) {
 			// WFX_LOG_LEVEL becomes log-level
 			key := strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "WFX_")), "_", "-")
-			// Header fields are read with k.Strings, which does not convert scalar strings.
-			if key == ClientHeaderFlag || key == MgmtHeaderFlag {
+			// Header is read with k.Strings, which does not convert scalar strings.
+			if key == HeaderFlag {
 				return key, []string{v}
 			}
 			return key, v
@@ -176,41 +152,28 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 	}
 
 	return BaseCmd{
-		ClientID:    k.String(ClientIDFlag),
-		ClientIDs:   k.Strings(ClientIDFlag),
-		ColorMode:   k.String(ColorFlag),
-		EnableTLS:   k.Bool(EnableTLSFlag),
-		Filter:      k.String(FilterFlag),
-		Groups:      k.Strings(GroupFlag),
-		History:     k.Bool(HistoryFlag),
-		Host:        k.String(ClientHostFlag),
-		ID:          k.String(IDFlag),
-		JobIDs:      k.Strings(JobIDFlag),
-		MgmtHost:    k.String(MgmtHostFlag),
-		MgmtPort:    k.Int(MgmtPortFlag),
-		MgmtSocket:  k.String(MgmtUnixSocketFlag),
-		MgmtTLSHost: k.String(MgmtTLSHostFlag),
-		MgmtTLSPort: k.Int(MgmtTLSPortFlag),
-		Offset:      k.Int64(OffsetFlag),
-		Port:        k.Int(ClientPortFlag),
-		RawOutput:   k.Bool(RawFlag),
-		Socket:      k.String(ClientUnixSocketFlag),
-		Sort:        k.String(SortFlag),
-		TLSCa:       k.String(TLSCaFlag),
-		TLSHost:     k.String(ClientTLSHostFlag),
-		TLSPort:     k.Int(ClientTLSPortFlag),
-		Tags:        tags,
-		Workflow:    k.String(WorkflowFlag),
-		Workflows:   k.Strings(WorkflowFlag),
-		Progress:    k.Int(ProgressFlag),
-		Message:     k.String(MessageFlag),
-		State:       k.String(StateFlag),
-		Actor:       k.String(ActorFlag),
-		Name:        k.String(NameFlag),
-		Limit:       int32(k.Int(LimitFlag)),
-
-		ClientHdrs:       k.Strings(ClientHeaderFlag),
-		MgmtHdrs:         k.Strings(MgmtHeaderFlag),
+		ClientID:         k.String(ClientIDFlag),
+		ClientIDs:        k.Strings(ClientIDFlag),
+		ColorMode:        k.String(ColorFlag),
+		Filter:           k.String(FilterFlag),
+		Groups:           k.Strings(GroupFlag),
+		History:          k.Bool(HistoryFlag),
+		Host:             k.String(HostFlag),
+		ID:               k.String(IDFlag),
+		JobIDs:           k.Strings(JobIDFlag),
+		Offset:           k.Int64(OffsetFlag),
+		RawOutput:        k.Bool(RawFlag),
+		Sort:             k.String(SortFlag),
+		TLSCa:            k.String(TLSCaFlag),
+		Tags:             tags,
+		Workflow:         k.String(WorkflowFlag),
+		Workflows:        k.Strings(WorkflowFlag),
+		Progress:         k.Int(ProgressFlag),
+		Message:          k.String(MessageFlag),
+		State:            k.String(StateFlag),
+		Name:             k.String(NameFlag),
+		Limit:            int32(k.Int(LimitFlag)),
+		Headers:          k.Strings(HeaderFlag),
 		CredentialHelper: k.String(CredentialHelperFlag),
 	}
 }
@@ -232,32 +195,31 @@ func (b *BaseCmd) SortParam() (*api.SortEnum, error) {
 }
 
 func (b *BaseCmd) CreateHTTPClient() (*http.Client, error) {
-	sockets := make([]string, 0, 2)
-	if b.Socket != "" {
-		sockets = append(sockets, b.Socket)
+	u, err := url.Parse(b.Host)
+	if err != nil {
+		return nil, errors.New("invalid host URL")
 	}
-	if b.MgmtSocket != "" {
-		sockets = append(sockets, b.MgmtSocket)
-	}
-	if n := len(sockets); n > 0 {
-		if n == 2 {
-			return nil, fmt.Errorf("you cannot use both --%s and --%s at the same time", ClientUnixSocketFlag, MgmtUnixSocketFlag)
+	switch u.Scheme {
+	case "http", "https":
+		if u.Host == "" {
+			u.User = nil
+			return nil, fmt.Errorf("host missing from %q", u.String())
 		}
-		socket := sockets[0]
-		addr, err := net.ResolveUnixAddr("unix", socket)
-		if err != nil {
-			return nil, fault.Wrap(err)
+	case "unix":
+		if u.Host != "" || u.Path == "" {
+			return nil, fmt.Errorf("unix host must have form unix:///path/to/socket")
 		}
-		log.Info().Msg("Using unix-domain socket transport")
 		return &http.Client{
 			Transport: &http.Transport{
-				Dial: func(_, _ string) (net.Conn, error) {
-					conn, err := net.DialUnix("unix", nil, addr)
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					conn, err := (&net.Dialer{}).DialContext(ctx, "unix", u.Path)
 					return conn, fault.Wrap(err)
 				},
 			},
 			Timeout: time.Second * 10,
 		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported host scheme %q (want http, https, or unix)", u.Scheme)
 	}
 
 	tlsConfig := new(tls.Config)
@@ -286,53 +248,50 @@ func (b *BaseCmd) CreateHTTPClient() (*http.Client, error) {
 	}, nil
 }
 
-func (b *BaseCmd) CreateClient() (*api.Client, error) {
-	var server string
+func (b *BaseCmd) server() string {
 	swagger := errutil.Must(api.GetSpec())
 	basePath := errutil.Must(swagger.Servers.BasePath())
-	if b.EnableTLS {
-		server = fmt.Sprintf("https://%s:%d%s", b.TLSHost, b.TLSPort, basePath)
-	} else {
-		server = fmt.Sprintf("http://%s:%d%s", b.Host, b.Port, basePath)
+	u, err := url.Parse(b.Host)
+	if err == nil && u.Scheme == "unix" {
+		return "http://localhost" + basePath
 	}
-	log.Debug().Str("server", server).Msgf("Creating client for %q", server)
+	return strings.TrimRight(b.Host, "/") + basePath
+}
+
+func (b *BaseCmd) ServerRedacted() string {
+	u, err := url.Parse(b.server())
+	if err != nil {
+		return ""
+	}
+	u.User = nil
+	return u.String()
+}
+
+func (b *BaseCmd) CreateClient(opts ...api.ClientOption) (*api.Client, error) {
+	server := b.server()
+	log.Debug().Msgf("Creating client for %q", b.ServerRedacted())
 	httpClient, err := b.CreateHTTPClient()
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	editor, err := httpclient.RequestEditor(b.ClientHdrs, b.CredentialHelper)
+	editor, err := httpclient.RequestEditor(b.Headers, b.CredentialHelper)
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	client, err := api.NewClient(server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(editor))
+	opts = append([]api.ClientOption{api.WithHTTPClient(httpClient), api.WithRequestEditorFn(editor)}, opts...)
+	client, err := api.NewClient(server, opts...)
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
 	return client, nil
 }
 
-func (b *BaseCmd) CreateMgmtClient() (*api.Client, error) {
-	var server string
-	swagger := errutil.Must(api.GetSpec())
-	basePath := errutil.Must(swagger.Servers.BasePath())
-	if b.EnableTLS {
-		server = fmt.Sprintf("https://%s:%d%s", b.MgmtTLSHost, b.MgmtTLSPort, basePath)
-	} else {
-		server = fmt.Sprintf("http://%s:%d%s", b.MgmtHost, b.MgmtPort, basePath)
-	}
-	httpClient, err := b.CreateHTTPClient()
+func (b *BaseCmd) CreateClientWithResponses(opts ...api.ClientOption) (*api.ClientWithResponses, error) {
+	client, err := b.CreateClient(opts...)
 	if err != nil {
-		return nil, fault.Wrap(err)
+		return nil, err
 	}
-	editor, err := httpclient.RequestEditor(b.MgmtHdrs, b.CredentialHelper)
-	if err != nil {
-		return nil, fault.Wrap(err)
-	}
-	client, err := api.NewClient(server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(editor))
-	if err != nil {
-		return nil, fault.Wrap(err)
-	}
-	return client, nil
+	return &api.ClientWithResponses{ClientInterface: client}, nil
 }
 
 func (b *BaseCmd) ProcessResponse(resp *http.Response, w io.Writer) error {

--- a/cmd/wfxctl/flags/basecmd.go
+++ b/cmd/wfxctl/flags/basecmd.go
@@ -31,12 +31,14 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/siemens/wfx/cmd/wfxctl/errutil"
+	"github.com/siemens/wfx/cmd/wfxctl/httpclient"
 	"github.com/siemens/wfx/generated/api"
 	"github.com/spf13/pflag"
 )
 
 const (
 	ActorFlag            = "actor"
+	ClientHeaderFlag     = "client-hdr"
 	ClientHostFlag       = "client-host"
 	ClientIDFlag         = "client-id"
 	ClientPortFlag       = "client-port"
@@ -54,6 +56,7 @@ const (
 	LimitFlag            = "limit"
 	LogLevelFlag         = "log-level"
 	MessageFlag          = "message"
+	MgmtHeaderFlag       = "mgmt-hdr"
 	MgmtHostFlag         = "mgmt-host"
 	MgmtPortFlag         = "mgmt-port"
 	MgmtTLSHostFlag      = "mgmt-tls-host"
@@ -109,6 +112,9 @@ type BaseCmd struct {
 	Actor     string
 	Name      string
 	Limit     int32
+
+	ClientHdrs []string
+	MgmtHdrs   []string
 }
 
 func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
@@ -137,7 +143,12 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 		Prefix: "WFX",
 		TransformFunc: func(k string, v string) (string, any) {
 			// WFX_LOG_LEVEL becomes log-level
-			return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "WFX_")), "_", "-"), v
+			key := strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "WFX_")), "_", "-")
+			// Header fields are read with k.Strings, which does not convert scalar strings.
+			if key == ClientHeaderFlag || key == MgmtHeaderFlag {
+				return key, []string{v}
+			}
+			return key, v
 		},
 	})
 	if err := k.Load(envProvider, nil); err != nil {
@@ -195,6 +206,9 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 		Actor:       k.String(ActorFlag),
 		Name:        k.String(NameFlag),
 		Limit:       int32(k.Int(LimitFlag)),
+
+		ClientHdrs: k.Strings(ClientHeaderFlag),
+		MgmtHdrs:   k.Strings(MgmtHeaderFlag),
 	}
 }
 
@@ -283,7 +297,11 @@ func (b *BaseCmd) CreateClient() (*api.Client, error) {
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	client, err := api.NewClient(server, api.WithHTTPClient(httpClient))
+	editor, err := httpclient.RequestEditor(b.ClientHdrs)
+	if err != nil {
+		return nil, fault.Wrap(err)
+	}
+	client, err := api.NewClient(server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(editor))
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
@@ -303,7 +321,11 @@ func (b *BaseCmd) CreateMgmtClient() (*api.Client, error) {
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	client, err := api.NewClient(server, api.WithHTTPClient(httpClient))
+	editor, err := httpclient.RequestEditor(b.MgmtHdrs)
+	if err != nil {
+		return nil, fault.Wrap(err)
+	}
+	client, err := api.NewClient(server, api.WithHTTPClient(httpClient), api.WithRequestEditorFn(editor))
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}

--- a/cmd/wfxctl/flags/basecmd.go
+++ b/cmd/wfxctl/flags/basecmd.go
@@ -47,6 +47,7 @@ const (
 	ClientUnixSocketFlag = "client-unix-socket"
 	ColorFlag            = "color"
 	ConfigFlag           = "config"
+	CredentialHelperFlag = "credential-helper"
 	EnableTLSFlag        = "enable-tls"
 	FilterFlag           = "filter"
 	GroupFlag            = "group"
@@ -113,8 +114,9 @@ type BaseCmd struct {
 	Name      string
 	Limit     int32
 
-	ClientHdrs []string
-	MgmtHdrs   []string
+	ClientHdrs       []string
+	MgmtHdrs         []string
+	CredentialHelper string
 }
 
 func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
@@ -207,8 +209,9 @@ func NewBaseCmd(f *pflag.FlagSet) BaseCmd {
 		Name:        k.String(NameFlag),
 		Limit:       int32(k.Int(LimitFlag)),
 
-		ClientHdrs: k.Strings(ClientHeaderFlag),
-		MgmtHdrs:   k.Strings(MgmtHeaderFlag),
+		ClientHdrs:       k.Strings(ClientHeaderFlag),
+		MgmtHdrs:         k.Strings(MgmtHeaderFlag),
+		CredentialHelper: k.String(CredentialHelperFlag),
 	}
 }
 
@@ -297,7 +300,7 @@ func (b *BaseCmd) CreateClient() (*api.Client, error) {
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	editor, err := httpclient.RequestEditor(b.ClientHdrs)
+	editor, err := httpclient.RequestEditor(b.ClientHdrs, b.CredentialHelper)
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
@@ -321,7 +324,7 @@ func (b *BaseCmd) CreateMgmtClient() (*api.Client, error) {
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	editor, err := httpclient.RequestEditor(b.MgmtHdrs)
+	editor, err := httpclient.RequestEditor(b.MgmtHdrs, b.CredentialHelper)
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}

--- a/cmd/wfxctl/flags/basecmd.go
+++ b/cmd/wfxctl/flags/basecmd.go
@@ -349,6 +349,9 @@ func (b *BaseCmd) ProcessResponse(resp *http.Response, w io.Writer) error {
 		if err := json.Unmarshal(body, &errorResponse); err == nil {
 			errutil.ProcessErrorResponse(w, errorResponse)
 		}
+		if len(body) == 0 {
+			return fmt.Errorf("empty body, HTTP status %d", statusCode)
+		}
 		return fmt.Errorf("error: %s", string(body))
 	}
 	return nil

--- a/cmd/wfxctl/flags/basecmd_test.go
+++ b/cmd/wfxctl/flags/basecmd_test.go
@@ -10,6 +10,7 @@ package flags
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +54,7 @@ CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
 	t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
 
 	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.EnableTLS = true
+	b.Host = "https://localhost:8081"
 	b.TLSCa = tmpFile.Name()
 
 	client, _ := b.CreateHTTPClient()
@@ -61,51 +62,44 @@ CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
 	assert.NotEmpty(t, transport.TLSClientConfig.RootCAs)
 }
 
-func TestCreateHTTPClient_AmbiguousSockets(t *testing.T) {
-	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.Socket = "foo"
-	b.MgmtSocket = "bar"
-	_, err := b.CreateHTTPClient()
-	require.Error(t, err)
+func TestCreateClient(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		host     string
+		expected string
+		redacted string
+	}{
+		{name: "HTTP", host: "http://localhost:8081", expected: "http://localhost:8081/api/wfx/v1/"},
+		{name: "HTTPS", host: "https://localhost:8081", expected: "https://localhost:8081/api/wfx/v1/"},
+		{name: "Basic auth", host: "https://user:secret@localhost:8081", expected: "https://user:secret@localhost:8081/api/wfx/v1/", redacted: "https://localhost:8081/api/wfx/v1"},
+		{name: "Unix", host: "unix:///tmp/wfx.sock", expected: "http://localhost/api/wfx/v1/"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
+			b.Host = tt.host
+
+			client, err := b.CreateClient()
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, client.Server)
+			if tt.redacted != "" {
+				assert.Equal(t, tt.redacted, b.ServerRedacted())
+				assert.NotContains(t, b.ServerRedacted(), "user")
+				assert.NotContains(t, b.ServerRedacted(), "secret")
+			}
+		})
+	}
 }
 
-func TestCreateHTTPClient_Socket(t *testing.T) {
+func TestCreateHTTPClientUnix(t *testing.T) {
 	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.Socket = "/tmp/foo.sock"
-	_, err := b.CreateHTTPClient()
+	b.Host = "unix:///tmp/wfx.sock"
+	client, err := b.CreateHTTPClient()
 	require.NoError(t, err)
-}
 
-func TestCreateClient_TLS(t *testing.T) {
-	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.EnableTLS = true
-	client, err := b.CreateClient()
-	assert.NotNil(t, client)
-	assert.NoError(t, err)
-}
-
-func TestCreateClient_NoTLS(t *testing.T) {
-	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.EnableTLS = false
-	client, err := b.CreateClient()
-	assert.NotNil(t, client)
-	assert.NoError(t, err)
-}
-
-func TestCreateMgmtClient(t *testing.T) {
-	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.EnableTLS = true
-	client, err := b.CreateMgmtClient()
-	assert.NotNil(t, client)
-	assert.NoError(t, err)
-}
-
-func TestCreateMgmtClient_NoTLS(t *testing.T) {
-	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
-	b.EnableTLS = false
-	client, err := b.CreateMgmtClient()
-	assert.NotNil(t, client)
-	assert.NoError(t, err)
+	transport := client.Transport.(*http.Transport)
+	_, err = transport.DialContext(context.Background(), "tcp", "ignored")
+	assert.ErrorContains(t, err, "/tmp/wfx.sock")
 }
 
 func TestDumpPlain(t *testing.T) {
@@ -253,15 +247,15 @@ func TestNewBaseCmd_EnvVariables(t *testing.T) {
 	assert.Equal(t, zerolog.TraceLevel, zerolog.GlobalLevel())
 }
 
-func TestNewBaseCmd_EnvHeaders(t *testing.T) {
-	t.Setenv("WFX_CLIENT_HDR", "Authorization: Bearer client-token")
-	t.Setenv("WFX_MGMT_HDR", "Authorization: Bearer mgmt-token")
+func TestNewBaseCmd_EnvHostAndHeaders(t *testing.T) {
+	t.Setenv("WFX_HOST", "https://example.com:1234")
+	t.Setenv("WFX_HEADER", "Authorization: Bearer token")
 	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	f.StringArray(ClientHeaderFlag, nil, "")
-	f.StringArray(MgmtHeaderFlag, nil, "")
+	f.String(HostFlag, "http://localhost:8081", "")
+	f.StringArray(HeaderFlag, nil, "")
 
 	b := NewBaseCmd(f)
 
-	assert.Equal(t, []string{"Authorization: Bearer client-token"}, b.ClientHdrs)
-	assert.Equal(t, []string{"Authorization: Bearer mgmt-token"}, b.MgmtHdrs)
+	assert.Equal(t, "https://example.com:1234", b.Host)
+	assert.Equal(t, []string{"Authorization: Bearer token"}, b.Headers)
 }

--- a/cmd/wfxctl/flags/basecmd_test.go
+++ b/cmd/wfxctl/flags/basecmd_test.go
@@ -169,7 +169,7 @@ func TestProcessResponse_Error(t *testing.T) {
 	buf := new(bytes.Buffer)
 	b := NewBaseCmd(pflag.NewFlagSet("wfx", pflag.ExitOnError))
 	err := b.ProcessResponse(resp, buf)
-	assert.Error(t, err)
+	require.EqualError(t, err, "empty body, HTTP status 500")
 }
 
 func TestProcessResponse_ErrorResponse(t *testing.T) {

--- a/cmd/wfxctl/flags/basecmd_test.go
+++ b/cmd/wfxctl/flags/basecmd_test.go
@@ -252,3 +252,16 @@ func TestNewBaseCmd_EnvVariables(t *testing.T) {
 	NewBaseCmd(f)
 	assert.Equal(t, zerolog.TraceLevel, zerolog.GlobalLevel())
 }
+
+func TestNewBaseCmd_EnvHeaders(t *testing.T) {
+	t.Setenv("WFX_CLIENT_HDR", "Authorization: Bearer client-token")
+	t.Setenv("WFX_MGMT_HDR", "Authorization: Bearer mgmt-token")
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	f.StringArray(ClientHeaderFlag, nil, "")
+	f.StringArray(MgmtHeaderFlag, nil, "")
+
+	b := NewBaseCmd(f)
+
+	assert.Equal(t, []string{"Authorization: Bearer client-token"}, b.ClientHdrs)
+	assert.Equal(t, []string{"Authorization: Bearer mgmt-token"}, b.MgmtHdrs)
+}

--- a/cmd/wfxctl/httpclient/credential.go
+++ b/cmd/wfxctl/httpclient/credential.go
@@ -1,0 +1,102 @@
+package httpclient
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+
+	"github.com/Southclaws/fault"
+)
+
+type credential struct {
+	username       string
+	password       string
+	authType       string
+	authCredential string
+	hasUsername    bool
+	hasPassword    bool
+}
+
+func credentialHelperName(helper string) string {
+	if strings.ContainsRune(helper, '/') {
+		return helper
+	}
+	return "wfxctl-credential-" + helper
+}
+
+func getCredential(ctx context.Context, helper string, u *url.URL) (credential, error) {
+	cmd := exec.CommandContext(ctx, credentialHelperName(helper), "get")
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("protocol=%s\nhost=%s\npath=%s\n\n", u.Scheme, u.Host, strings.TrimPrefix(u.Path, "/")))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return credential{}, fmt.Errorf("credential helper failed: %s: %w", message, err)
+		}
+		return credential{}, fmt.Errorf("credential helper failed: %w", err)
+	}
+
+	var result credential
+	for line := range strings.SplitSeq(string(output), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if line == "" {
+			break
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			return credential{}, fmt.Errorf("invalid response from credential helper: expected key=value")
+		}
+		switch key {
+		case "username":
+			result.username, result.hasUsername = value, true
+		case "password":
+			result.password, result.hasPassword = value, true
+		case "authtype":
+			result.authType = value
+		case "credential":
+			result.authCredential = value
+		}
+	}
+	return result, nil
+}
+
+func (c credential) authorization() (string, error) {
+	switch {
+	case c.authType != "" && c.authCredential != "":
+		if strings.ContainsAny(c.authType+c.authCredential, "\r\n") {
+			return "", fmt.Errorf("invalid credential helper response")
+		}
+		return c.authType + " " + c.authCredential, nil
+	case c.hasUsername && c.hasPassword:
+		value := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+		return "Basic " + value, nil
+	default:
+		return "", fmt.Errorf("credential helper returned no complete credential")
+	}
+}
+
+func addCredential(ctx context.Context, helper string, req *http.Request) error {
+	credential, err := getCredential(ctx, helper, req.URL)
+	if err != nil {
+		return fault.Wrap(err)
+	}
+	authorization, err := credential.authorization()
+	if err != nil {
+		return fault.Wrap(err)
+	}
+	req.Header.Set("Authorization", authorization)
+	return nil
+}

--- a/cmd/wfxctl/httpclient/credential_test.go
+++ b/cmd/wfxctl/httpclient/credential_test.go
@@ -1,0 +1,78 @@
+package httpclient
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func credentialHelper(t *testing.T, response string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	input := filepath.Join(dir, "input")
+	helper := filepath.Join(dir, "helper")
+	script := "#!/bin/sh\ncat >" + input + "\nprintf '%s' '" + response + "'\n"
+	require.NoError(t, os.WriteFile(helper, []byte(script), 0o700))
+	return helper, input
+}
+
+func TestCredentialRequestEditorBasic(t *testing.T) {
+	helper, input := credentialHelper(t, "username=user\npassword=secret\n\n")
+	editor, err := RequestEditor(nil, helper)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com:8443/api/wfx/v1/jobs", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, editor(req.Context(), req))
+	assert.Equal(t, "Basic dXNlcjpzZWNyZXQ=", req.Header.Get("Authorization"))
+	payload, err := os.ReadFile(input)
+	require.NoError(t, err)
+	assert.Equal(t, "protocol=https\nhost=example.com:8443\npath=api/wfx/v1/jobs\n\n", string(payload))
+}
+
+func TestCredentialRequestEditorAuthType(t *testing.T) {
+	helper, _ := credentialHelper(t, "authtype=Bearer\ncredential=token\n\n")
+	editor, err := RequestEditor(nil, helper)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, editor(req.Context(), req))
+	assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+}
+
+func TestCredentialRequestEditorPreservesAuthorization(t *testing.T) {
+	editor, err := RequestEditor(nil, "missing-helper")
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer explicit")
+
+	require.NoError(t, editor(req.Context(), req))
+	assert.Equal(t, "Bearer explicit", req.Header.Get("Authorization"))
+}
+
+func TestCredentialRequestEditorIncompleteCredential(t *testing.T) {
+	helper, _ := credentialHelper(t, "username=user\n\n")
+	editor, err := RequestEditor(nil, helper)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+	require.NoError(t, err)
+
+	require.ErrorContains(t, editor(req.Context(), req), "credential helper returned no complete credential")
+}
+
+func TestCredentialHelperName(t *testing.T) {
+	assert.Equal(t, "wfxctl-credential-store", credentialHelperName("store"))
+	assert.Equal(t, "/usr/bin/helper", credentialHelperName("/usr/bin/helper"))
+}

--- a/cmd/wfxctl/httpclient/header.go
+++ b/cmd/wfxctl/httpclient/header.go
@@ -1,0 +1,52 @@
+package httpclient
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Southclaws/fault"
+	"github.com/siemens/wfx/generated/api"
+	"golang.org/x/net/http/httpguts"
+)
+
+// parseHeader parses a single "Name: Value" pair as accepted by curl's -H flag.
+func parseHeader(header string) (string, string, error) {
+	name, value, found := strings.Cut(header, ":")
+	if !found || !httpguts.ValidHeaderFieldName(name) || !httpguts.ValidHeaderFieldValue(value) {
+		return "", "", errors.New("invalid header, expected format 'Name: Value'")
+	}
+	return name, strings.Trim(value, " \t"), nil
+}
+
+// RequestEditor returns a RequestEditorFn which adds custom headers to each
+// outgoing request. Headers are parsed eagerly so invalid input fails immediately.
+func RequestEditor(values []string) (api.RequestEditorFn, error) {
+	headers := make(http.Header, len(values))
+	for _, header := range values {
+		name, value, err := parseHeader(header)
+		if err != nil {
+			return nil, fault.Wrap(err)
+		}
+		headers.Add(name, value)
+	}
+	return func(_ context.Context, req *http.Request) error {
+		for name, values := range headers {
+			if name == "Host" {
+				req.Host = values[len(values)-1]
+				continue
+			}
+			req.Header[name] = values
+		}
+		return nil
+	}, nil
+}

--- a/cmd/wfxctl/httpclient/header.go
+++ b/cmd/wfxctl/httpclient/header.go
@@ -30,7 +30,7 @@ func parseHeader(header string) (string, string, error) {
 
 // RequestEditor returns a RequestEditorFn which adds custom headers to each
 // outgoing request. Headers are parsed eagerly so invalid input fails immediately.
-func RequestEditor(values []string) (api.RequestEditorFn, error) {
+func RequestEditor(values []string, credentialHelper string) (api.RequestEditorFn, error) {
 	headers := make(http.Header, len(values))
 	for _, header := range values {
 		name, value, err := parseHeader(header)
@@ -39,7 +39,7 @@ func RequestEditor(values []string) (api.RequestEditorFn, error) {
 		}
 		headers.Add(name, value)
 	}
-	return func(_ context.Context, req *http.Request) error {
+	return func(ctx context.Context, req *http.Request) error {
 		for name, values := range headers {
 			if name == "Host" {
 				req.Host = values[len(values)-1]
@@ -47,6 +47,9 @@ func RequestEditor(values []string) (api.RequestEditorFn, error) {
 			}
 			req.Header[name] = values
 		}
-		return nil
+		if credentialHelper == "" || req.Header.Get("Authorization") != "" {
+			return nil
+		}
+		return addCredential(ctx, credentialHelper, req)
 	}, nil
 }

--- a/cmd/wfxctl/httpclient/header_test.go
+++ b/cmd/wfxctl/httpclient/header_test.go
@@ -1,0 +1,71 @@
+package httpclient
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHeader(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		name  string
+		value string
+		err   bool
+	}{
+		{input: "Authorization: Bearer foo", name: "Authorization", value: "Bearer foo"},
+		{input: "X-Foo:bar", name: "X-Foo", value: "bar"},
+		{input: "X-Foo:", name: "X-Foo", value: ""},
+		{input: "X-Time: 12:30", name: "X-Time", value: "12:30"},
+		{input: "no-colon", err: true},
+		{input: ": value", err: true},
+		{input: "Bad Name: value", err: true},
+		{input: "Bad(Name): value", err: true},
+		{input: "X-Foo: value\r\nInjected: true", err: true},
+		{input: "X-Foo: value\x00", err: true},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			name, value, err := parseHeader(tc.input)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.name, name)
+			assert.Equal(t, tc.value, value)
+		})
+	}
+}
+
+func TestRequestEditor(t *testing.T) {
+	editor, err := RequestEditor([]string{"X-Foo: bar", "X-Foo: baz", "X-Other:quux", "Host: example.com"})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Foo", "generated")
+	require.NoError(t, editor(req.Context(), req))
+
+	assert.Equal(t, []string{"bar", "baz"}, req.Header.Values("X-Foo"))
+	assert.Equal(t, "quux", req.Header.Get("X-Other"))
+	assert.Equal(t, "example.com", req.Host)
+	assert.Empty(t, req.Header.Values("Host"))
+}
+
+func TestRequestEditor_InvalidDoesNotLeakHeader(t *testing.T) {
+	const header = "Authorization Bearer secret"
+	editor, err := RequestEditor([]string{header})
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), header)
+	assert.Nil(t, editor)
+}

--- a/cmd/wfxctl/httpclient/header_test.go
+++ b/cmd/wfxctl/httpclient/header_test.go
@@ -48,7 +48,7 @@ func TestParseHeader(t *testing.T) {
 }
 
 func TestRequestEditor(t *testing.T) {
-	editor, err := RequestEditor([]string{"X-Foo: bar", "X-Foo: baz", "X-Other:quux", "Host: example.com"})
+	editor, err := RequestEditor([]string{"X-Foo: bar", "X-Foo: baz", "X-Other:quux", "Host: example.com"}, "")
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
@@ -64,7 +64,7 @@ func TestRequestEditor(t *testing.T) {
 
 func TestRequestEditor_InvalidDoesNotLeakHeader(t *testing.T) {
 	const header = "Authorization Bearer secret"
-	editor, err := RequestEditor([]string{header})
+	editor, err := RequestEditor([]string{header}, "")
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), header)
 	assert.Nil(t, editor)

--- a/cmd/wfxctl/httpclient/main_test.go
+++ b/cmd/wfxctl/httpclient/main_test.go
@@ -1,0 +1,19 @@
+package httpclient
+
+/*
+ * SPDX-FileCopyrightText: 2026 Siemens AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Author: Michael Adler <michael.adler@siemens.com>
+ */
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,8 +42,8 @@ credential=secret-token
 
 ```
 
-An explicit `Authorization` header set with `--client-hdr` or `--mgmt-hdr` takes
-precedence over the credential helper.
+An explicit `Authorization` header set with `--header` takes precedence over
+the credential helper.
 
 ## Systemd Integration
 
@@ -57,10 +57,10 @@ systemctl enable --now wfx@foo.socket
 systemctl enable --now wfx@bar.socket
 ```
 
-The wfx services launch on-demand, i.e., they start when a client connects, such as when retrieving the wfx version:
+The wfx services launch on-demand, i.e., they start when a client connects:
 
 ```bash
-wfxctl --client-unix-socket /var/run/wfx/foo/client.sock version
+wfxctl --host unix:///var/run/wfx/foo/client.sock version
 ```
 
 ## Persistent Storage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,11 +169,12 @@ The following connectivity parameters are available:
 
 ## Cross-Origin Resource Sharing (CORS)
 
-The API servers add CORS headers to responses, allowing browser-based clients to access wfx directly.
-The following parameters control these headers:
+CORS headers are disabled by default and never applied to the southbound API.
+The following parameters control CORS for the northbound API:
 
 | Parameter                  | Description                                                                                                                                                                       |
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cors-enabled`           | Add CORS headers to northbound API responses; disabled by default                                                                                                                  |
 | `--cors-allowed-origins`   | One or multiple origins allowed to make cross-origin requests; defaults to `*` (any origin)                                                                                       |
 | `--cors-allowed-methods`   | One or multiple methods allowed when making cross-origin requests; defaults to `GET,HEAD,POST,PUT,PATCH,DELETE`                                                                   |
 | `--cors-allowed-headers`   | One or multiple headers allowed when making cross-origin requests; defaults to `*` (any header)                                                                                   |
@@ -183,10 +184,10 @@ The following parameters control these headers:
 `--cors-allow-credentials` requires explicit origins. Configuration is rejected if
 `--cors-allowed-origins` contains `*` while credentials are enabled.
 
-For example, to restrict access to a single origin:
+For example, to enable CORS headers:
 
 ```bash
-wfx --cors-allowed-origins https://wfx.example.com
+wfx --cors-enabled --cors-allowed-origins https://wfx-ui.company.cloud
 ```
 
 ## File Server

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,33 @@ starts wfx using the built-in SQLite-based persistent storage.
 The northbound (management) API is available at `http://127.0.0.1:8081/api/wfx/v1/`,
 whereas the southbound (client) API is available at a different port: `http://127.0.0.1:8080/api/wfx/v1`.
 
+## wfxctl credential helpers
+
+`wfxctl` can delegate HTTP authentication to a Git-style credential helper. Set
+`--credential-helper=<name>` to run `wfxctl-credential-<name> get`, or pass a
+path containing `/` to run that executable directly. `WFX_CREDENTIAL_HELPER`
+and the `credential-helper` YAML key are also supported.
+
+The helper receives `protocol`, `host`, and `path` fields on standard input. It
+must return either `username` and `password` for Basic authentication, or
+`authtype` and `credential` for schemes such as Bearer authentication:
+
+```text
+protocol=https
+host=wfx.example.com
+path=api/wfx/v1/jobs
+
+```
+
+```text
+authtype=Bearer
+credential=secret-token
+
+```
+
+An explicit `Authorization` header set with `--client-hdr` or `--mgmt-hdr` takes
+precedence over the credential helper.
+
 ## Systemd Integration
 
 For production deployments, it's recommended to run wfx under a service supervisor such as [systemd](https://systemd.io).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -285,8 +285,7 @@ they're actually able to process the job.
 Then, Developer Dana, knowing the job (Task) Identifier, pulls the task into "PROGRESS"
 
 ```sh
-wfxctl job update-status \
-    --actor=client \
+wfxctl --host http://localhost:8080 job update-status \
     --id=1 \
     --state=PROGRESS
 ```
@@ -306,8 +305,7 @@ curl -X PUT \
 Meanwhile, Developer Dana sporadically reports progress
 
 ```sh
-wfxctl job update-status \
-    --actor=client \
+wfxctl --host http://localhost:8080 job update-status \
     --id=1 \
     --state=PROGRESS \
     --progress $((RANDOM % 100))
@@ -316,8 +314,7 @@ wfxctl job update-status \
 until having finished the task and progressing it into the "VALIDATE" state:
 
 ```sh
-wfxctl job update-status \
-    --actor=client \
+wfxctl --host http://localhost:8080 job update-status \
     --id=1 \
     --state=VALIDATE
 ```

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -40,9 +40,6 @@ func NewHTTPServer(cfg *config.AppConfig, handler http.Handler) (*http.Server, e
 func configureTLS(server *http.Server, caCert string) error {
 	// Inspired by https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
 	server.TLSConfig = &tls.Config{
-		// Causes servers to use Go's default ciphersuite preferences,
-		// which are tuned to avoid attacks. Does nothing on clients.
-		PreferServerCipherSuites: true,
 		// Only use curves which have assembly implementations
 		// https://github.com/golang/go/tree/master/src/crypto/elliptic
 		CurvePreferences: []tls.CurveID{tls.CurveP256},

--- a/internal/server/job_events_test.go
+++ b/internal/server/job_events_test.go
@@ -37,11 +37,23 @@ func TestJobEventsSubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	north, south := createNorthAndSouth(t, db)
+	corsNorth, _ := createNorthAndSouth(t, db,
+		"--cors-enabled",
+		"--cors-allowed-origins", "https://example.com",
+	)
 
-	handlers := []http.Handler{north, south}
-	for i, name := range allAPIs {
-		handler := handlers[i]
-		t.Run(name, func(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.Handler
+		corsOrigin string
+	}{
+		{name: "north", handler: north},
+		{name: "south", handler: south},
+		{name: "north-cors", handler: corsNorth, corsOrigin: "https://example.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := tc.handler
 			clientID := "TestJobEventsSubscribe"
 
 			var jobID atomic.Pointer[string]
@@ -86,6 +98,7 @@ func TestJobEventsSubscribe(t *testing.T) {
 			rec := sse.NewMockResponseRecorder(t)
 			wg.Go(func() {
 				req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/wfx/v1/jobs/events?ids=%s", *jobID.Load()), nil)
+				req.Header.Set("Origin", "https://example.com")
 				handler.ServeHTTP(rec, req.WithContext(ctx))
 			})
 
@@ -99,13 +112,22 @@ func TestJobEventsSubscribe(t *testing.T) {
 
 			assert.Contains(t, response, "HTTP/1.1 200")
 			assert.Contains(t, response, "Content-Type: text/event-stream")
+			if tc.corsOrigin == "" {
+				assert.NotContains(t, response, "Access-Control-Allow-Origin")
+			} else {
+				assert.Contains(t, response, "Access-Control-Allow-Origin: "+tc.corsOrigin)
+			}
 
 			lines := strings.Split(response, "\r\n")
 			t.Log("HTTP response:")
 			for _, line := range lines {
 				t.Logf(">> %s", line)
 			}
-			assert.Len(t, lines, 8)
+			expectedLines := 7
+			if tc.corsOrigin != "" {
+				expectedLines += 2
+			}
+			assert.Len(t, lines, expectedLines)
 
 			lines = strings.Split(lines[len(lines)-1], "\n")
 

--- a/internal/server/server_collection.go
+++ b/internal/server/server_collection.go
@@ -49,15 +49,6 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	swag, _ := api.GetSpec()
 	validator := nethttpmiddleware.OapiRequestValidatorWithOptions(swag,
 		&nethttpmiddleware.Options{SilenceServersWarning: true})
-	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
-	// route of our mux, so a per-route middleware would never see them.
-	corsMW := cors.New(cors.Options{
-		AllowedOrigins:   cfg.CORSAllowedOrigins(),
-		AllowedMethods:   cfg.CORSAllowedMethods(),
-		AllowedHeaders:   cfg.CORSAllowedHeaders(),
-		AllowCredentials: cfg.CORSAllowCredentials(),
-		MaxAge:           cfg.CORSMaxAge(),
-	}).Handler
 	logMW := logging.NewLoggingMiddleware()
 
 	// LIFO
@@ -82,7 +73,23 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	northServer.Handler = corsMW(northServer.Handler)
+	// CORS must wrap the whole server: preflight (OPTIONS) requests match no
+	// route of our mux, so a per-route middleware would never see them.
+	northHandler := northServer.Handler
+	northServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		corsOpts := cfg.CORSOpts()
+		if !corsOpts.Enabled {
+			northHandler.ServeHTTP(w, r)
+			return
+		}
+		cors.New(cors.Options{
+			AllowedOrigins:   corsOpts.AllowedOrigins,
+			AllowedMethods:   corsOpts.AllowedMethods,
+			AllowedHeaders:   corsOpts.AllowedHeaders,
+			AllowCredentials: corsOpts.AllowCredentials,
+			MaxAge:           corsOpts.MaxAge,
+		}).Handler(northHandler).ServeHTTP(w, r)
+	})
 
 	southPluginMWs, err := createPluginMiddlewares(cfg.ClientPluginsDir())
 	if err != nil {
@@ -100,8 +107,6 @@ func NewServerCollection(cfg *config.AppConfig, wfx api.StrictServerInterface, s
 	if err != nil {
 		return nil, fault.Wrap(err)
 	}
-	southServer.Handler = corsMW(southServer.Handler)
-
 	return &ServerCollection{
 		cfg:          cfg,
 		storage:      storage,

--- a/internal/server/server_collection_test.go
+++ b/internal/server/server_collection_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/siemens/wfx/api"
 	"github.com/siemens/wfx/cmd/wfx/cmd/config"
@@ -36,14 +37,115 @@ func TestNewServerCollection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCORSConfigurableOrigins(t *testing.T) {
+func TestCORSNorthboundOnly(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil).Twice()
+	wfx := api.NewWfxServer(dbMock)
+
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name     string
+		handler  http.Handler
+		expected string
+	}{
+		{name: "north", handler: sc.North.Handler, expected: "*"},
+		{name: "south", handler: sc.South.Handler},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+			req.Header.Set("Origin", "https://example.com")
+			tc.handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tc.expected, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSReload(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	wfx := api.NewWfxServer(dbMock)
+
+	cfgFile := path.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: false\n"), 0o600))
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.ConfigFlag, cfgFile}))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	corsOrigin := func(origin string) string {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		sc.North.Handler.ServeHTTP(rec, req)
+		return rec.Header().Get("Access-Control-Allow-Origin")
+	}
+
+	assert.Empty(t, corsOrigin("https://one.example"))
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: true\ncors-allowed-origins: [https://one.example]\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://one.example") == "https://one.example"
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: true\ncors-allowed-origins: [https://two.example]\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://one.example") == "" && corsOrigin("https://two.example") == "https://two.example"
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, os.WriteFile(cfgFile, []byte("cors-enabled: false\n"), 0o600))
+	require.Eventually(t, func() bool {
+		return corsOrigin("https://two.example") == ""
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestCORSDisabledByDefault(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSAllowedOriginsFlag, "https://example.com"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse(nil))
+	cfg, err := config.NewAppConfig(flags)
+	require.NoError(t, err)
+	t.Cleanup(cfg.Stop)
+
+	sc, err := NewServerCollection(cfg, wfx, dbMock)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
+	req.Header.Set("Origin", "https://example.com")
+	sc.North.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSConfigurableOrigins(t *testing.T) {
+	dbMock := persistence.NewHealthyMockStorage(t)
+	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil).Twice()
+	wfx := api.NewWfxServer(dbMock)
+
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSAllowedOriginsFlag, "https://example.com",
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -55,16 +157,15 @@ func TestCORSConfigurableOrigins(t *testing.T) {
 		expected string
 	}{
 		{origin: "https://example.com", expected: "https://example.com"},
-		{origin: "https://evil.example.com", expected: ""},
+		{origin: "https://evil.example.com"},
 	} {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
 		req.Header.Set("Origin", tc.origin)
 		sc.North.Handler.ServeHTTP(rec, req)
 
-		result := rec.Result()
-		assert.Equal(t, http.StatusOK, result.StatusCode)
-		assert.Equal(t, tc.expected, result.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, tc.expected, rec.Header().Get("Access-Control-Allow-Origin"))
 	}
 }
 
@@ -72,9 +173,12 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSAllowedMethodsFlag, "GET"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSAllowedMethodsFlag, http.MethodGet,
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -84,14 +188,11 @@ func TestCORSPreflightAllowedMethods(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
-	req.Header.Set("Access-Control-Request-Method", "DELETE")
+	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	// disallowed method in preflight: cors middleware answers without CORS headers,
-	// so the browser rejects the actual request
-	result := rec.Result()
-	assert.Empty(t, result.Header.Get("Access-Control-Allow-Origin"))
-	assert.Empty(t, result.Header.Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Allow-Methods"))
 }
 
 func TestCORSAllowCredentials(t *testing.T) {
@@ -99,45 +200,45 @@ func TestCORSAllowCredentials(t *testing.T) {
 	dbMock.EXPECT().QueryJobs(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(new(genAPI.PaginatedJobList), nil)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
 		"--" + config.CORSAllowedOriginsFlag, "https://example.com",
 		"--" + config.CORSAllowCredentialsFlag,
-	})
-	cfg, err := config.NewAppConfig(f)
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
 	sc, err := NewServerCollection(cfg, wfx, dbMock)
 	require.NoError(t, err)
 
-	// actual request
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
 	sc.North.Handler.ServeHTTP(rec, req)
-	result := rec.Result()
-	assert.Equal(t, http.StatusOK, result.StatusCode)
-	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "true", rec.Header().Get("Access-Control-Allow-Credentials"))
 
-	// preflight request
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodOptions, "/api/wfx/v1/jobs", nil)
 	req.Header.Set("Origin", "https://example.com")
 	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
 	sc.North.Handler.ServeHTTP(rec, req)
-	result = rec.Result()
-	assert.Equal(t, http.StatusNoContent, result.StatusCode)
-	assert.Equal(t, "true", result.Header.Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "true", rec.Header().Get("Access-Control-Allow-Credentials"))
 }
 
 func TestCORSMaxAge(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{"--" + config.CORSMaxAgeFlag, "30s"})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{
+		"--" + config.CORSEnabledFlag,
+		"--" + config.CORSMaxAgeFlag, "30s",
+	}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -150,17 +251,16 @@ func TestCORSMaxAge(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	assert.Equal(t, "30", rec.Result().Header.Get("Access-Control-Max-Age"))
+	assert.Equal(t, "30", rec.Header().Get("Access-Control-Max-Age"))
 }
 
 func TestCORSMaxAgeDisabled(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	// default: no --cors-max-age flag, header must be omitted
-	f := config.NewFlagset()
-	_ = f.Parse(nil)
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -173,16 +273,16 @@ func TestCORSMaxAgeDisabled(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	assert.Empty(t, rec.Result().Header.Get("Access-Control-Max-Age"))
+	assert.Empty(t, rec.Header().Get("Access-Control-Max-Age"))
 }
 
-func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
+func TestCORSPreflight(t *testing.T) {
 	dbMock := persistence.NewHealthyMockStorage(t)
 	wfx := api.NewWfxServer(dbMock)
 
-	f := config.NewFlagset()
-	_ = f.Parse([]string{})
-	cfg, err := config.NewAppConfig(f)
+	flags := config.NewFlagset()
+	require.NoError(t, flags.Parse([]string{"--" + config.CORSEnabledFlag}))
+	cfg, err := config.NewAppConfig(flags)
 	require.NoError(t, err)
 	t.Cleanup(cfg.Stop)
 
@@ -196,9 +296,9 @@ func TestCORSDefaultAllowsAnyHeader(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Headers", "Authorization")
 	sc.North.Handler.ServeHTTP(rec, req)
 
-	result := rec.Result()
-	assert.Equal(t, "*", result.Header.Get("Access-Control-Allow-Origin"))
-	assert.Contains(t, strings.ToLower(result.Header.Get("Access-Control-Allow-Headers")), "authorization")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rec.Header().Get("Access-Control-Allow-Headers"), "Authorization")
 }
 
 func TestCreateServer_UseMiddlewares(t *testing.T) {

--- a/internal/server/workflow_test.go
+++ b/internal/server/workflow_test.go
@@ -235,8 +235,9 @@ func newInMemoryDB(t *testing.T) persistence.Storage {
 	return db
 }
 
-func createNorthAndSouth(t *testing.T, db persistence.Storage) (http.Handler, http.Handler) {
+func createNorthAndSouth(t *testing.T, db persistence.Storage, args ...string) (http.Handler, http.Handler) {
 	flagSet := config.NewFlagset()
+	require.NoError(t, flagSet.Parse(args))
 	cfg, err := config.NewAppConfig(flagSet)
 	require.NoError(t, err)
 

--- a/middleware/sse/responder.go
+++ b/middleware/sse/responder.go
@@ -45,6 +45,13 @@ func NewResponder(ctx context.Context, idleDuration time.Duration, subscriber *e
 func (responder Responder) VisitGetJobsEventsResponse(w http.ResponseWriter) error {
 	log := logging.LoggerFromCtx(responder.ctx).With().Str("subscriberID", responder.subscriber.ID()).Logger()
 
+	// Preserve headers set by middlewares
+	header := w.Header()
+	header.Set("Content-Type", "text/event-stream")
+	header.Set("Cache-Control", "no-cache")
+	header.Set("Connection", "keep-alive")
+	header.Set("X-Accel-Buffering", "no")
+
 	// Check if the ResponseWriter supports hijacking
 	hj, ok := w.(http.Hijacker)
 	if !ok { // e.g. if HTTP/2 is being used
@@ -63,13 +70,10 @@ func (responder Responder) VisitGetJobsEventsResponse(w http.ResponseWriter) err
 	}()
 
 	_, _ = fmt.Fprintf(bufrw, "HTTP/1.1 %d\r\n", http.StatusOK)
-	_, _ = bufrw.WriteString("Content-Type: text/event-stream\r\n")
-	_, _ = bufrw.WriteString("Cache-Control: no-cache\r\n")
-	_, _ = bufrw.WriteString("Connection: keep-alive\r\n")
-	_, _ = bufrw.WriteString("Access-Control-Allow-Origin: *\r\n")
-	_, _ = bufrw.WriteString("X-Accel-Buffering: no\r\n") // notify reverse proxy to disable buffering
-
-	// finish header section
+	// Hijacking bypasses net/http's header write, so include headers manually
+	if err := header.Write(bufrw); err != nil {
+		return fault.Wrap(err)
+	}
 	_, _ = bufrw.WriteString("\r\n")
 
 	if err := bufrw.Flush(); err != nil {

--- a/middleware/sse/responder_test.go
+++ b/middleware/sse/responder_test.go
@@ -43,6 +43,8 @@ func TestResponder(t *testing.T) {
 	})
 
 	rw := NewMockResponseRecorder(t)
+	rw.Header()["Invalid\r\nName"] = []string{"value"}
+	rw.Header().Set("X-Middleware", "safe\r\nInjected: yes")
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -72,6 +74,8 @@ func TestResponder(t *testing.T) {
 	assert.JSONEq(t, expected, string(objJson))
 	assert.Contains(t, resp, "id: 1")
 	assert.Contains(t, resp, "\n\n")
+	assert.NotContains(t, resp, "Invalid")
+	assert.Contains(t, resp, "X-Middleware: safe  Injected: yes\r\n")
 
 	cancel()
 	wg.Wait()

--- a/share/demo/config-deployment/03-start-client.sh
+++ b/share/demo/config-deployment/03-start-client.sh
@@ -13,7 +13,9 @@ clear
 
 echo "# waiting for wfx..."
 while true; do
-    UP_COUNT=$(wfxctl health | grep -c up)
+    UP_COUNT=0
+    wfxctl --host http://localhost:8080 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
+    wfxctl --host http://localhost:8081 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
     if [[ "$UP_COUNT" -ge 2 ]]; then
         break
     fi

--- a/share/demo/kanban/02-create-workflow.sh
+++ b/share/demo/kanban/02-create-workflow.sh
@@ -13,7 +13,9 @@ clear
 
 echo "# waiting for wfx..."
 while true; do
-    UP_COUNT=$(wfxctl health | grep -c up)
+    UP_COUNT=0
+    wfxctl --host http://localhost:8080 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
+    wfxctl --host http://localhost:8081 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
     if [[ "$UP_COUNT" -ge 2 ]]; then
         break
     fi

--- a/share/demo/kanban/04-consumer.sh
+++ b/share/demo/kanban/04-consumer.sh
@@ -14,7 +14,9 @@ source "$SCRIPT_DIR/../demo.sh"
 
 echo "# waiting for wfx..."
 while true; do
-    UP_COUNT=$(wfxctl health | grep -c up)
+    UP_COUNT=0
+    wfxctl --host http://localhost:8080 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
+    wfxctl --host http://localhost:8081 health | grep -q $'wfx\tup' && UP_COUNT=$((UP_COUNT+1))
     if [[ "$UP_COUNT" -ge 2 ]]; then
         break
     fi
@@ -45,7 +47,7 @@ while true; do
     p "wfxctl job query --limit 1 --client-id $CLIENT_ID --state=NEW --filter '.content.[].id' --raw"
     p "# found job with id $JOB_ID"
     for state in PROGRESS VALIDATE DONE; do
-        pe "wfxctl job update-status --id=$JOB_ID --state=$state"
+        pe "wfxctl --host http://localhost:8080 job update-status --id=$JOB_ID --state=$state"
         sleep 4
     done
     p "# task is done"

--- a/test/04-operations.bats
+++ b/test/04-operations.bats
@@ -22,7 +22,7 @@ teardown() {
   local i=0
   while [[ $i -lt 30 ]]; do
     RC=0
-    wfxctl --client-unix-socket "$BATS_TEST_TMPDIR/wfx-client.sock" version || RC=$?
+    wfxctl --host "unix://$BATS_TEST_TMPDIR/wfx-client.sock" version || RC=$?
     if [[ $RC -eq 0 ]]; then
         break
     fi

--- a/test/05-workflows.bats
+++ b/test/05-workflows.bats
@@ -32,35 +32,33 @@ teardown_file() {
              --client-id Dana \
              --filter='.id' --raw -)
 
+    SOUTHBOUND_HOST=http://localhost:8080
+
     # update job using wfxctl
-    wfxctl job update-status \
-        --actor=client \
+    wfxctl --host $SOUTHBOUND_HOST job update-status \
         "--id=$ID" \
         --state=PROGRESS
 
     # update job again using curl
     curl -X PUT \
-        "http://localhost:8080/api/wfx/v1/jobs/$ID/status" \
+        "$SOUTHBOUND_HOST/api/wfx/v1/jobs/$ID/status" \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         -d '{"state":"PROGRESS"}'
 
     # update progress
-    wfxctl job update-status \
-        --actor=client \
+    wfxctl --host $SOUTHBOUND_HOST job update-status \
         "--id=$ID" \
         --state=PROGRESS \
         --progress $((RANDOM % 100))
 
     # update state to VALIDATE
-    wfxctl job update-status \
-        --actor=client \
+    wfxctl --host $SOUTHBOUND_HOST job update-status \
         "--id=$ID" \
         --state=VALIDATE
 
     # update state to DONE
-    wfxctl job update-status \
-        --actor=client \
+    wfxctl --host $SOUTHBOUND_HOST job update-status \
         "--id=$ID" \
         --state=DONE
 }
@@ -101,9 +99,8 @@ teardown_file() {
     curl -s --no-buffer "localhost:8080/api/wfx/v1/jobs/events?jobIds=$ID&tags=bats" > curl.out &
     sleep 1
     for state in PROGRESS VALIDATE DONE; do
-        wfxctl job update-status \
-            --actor=client \
-            --id "$ID" \
+        wfxctl --host http://localhost:8080 job update-status \
+                --id "$ID" \
             --state "$state" 1>/dev/null 2>&1
     done
     for i in {1..30}; do

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -15,9 +15,10 @@ wait_wfx_running() {
     local expected=$1
     local count
     for _i in {1..20}; do
-        count=$(wfxctl health 2>/dev/null || echo "")
-        count=$(echo "$count" | grep -c up || true)
-        if [[ "${count:-0}" -eq "$expected" ]]; then
+        count=0
+        wfxctl --host http://localhost:8080 health 2>/dev/null | grep -q $'wfx\tup' && count=$((count+1))
+        wfxctl --host http://localhost:8081 health 2>/dev/null | grep -q $'wfx\tup' && count=$((count+1))
+        if [[ "$count" -eq "$expected" ]]; then
             break
         fi
         sleep 0.5


### PR DESCRIPTION
### Description

- Add global `wfxctl --header 'Name: Value'` flag (equivalent to curl)
- Add Git-style `wfxctl --credential-helper` support for Basic, Bearer, and other auth schemes.
  Explicit Authorization headers override helper credentials.
- Replace separate client/mgmt host, port, TLS, and Unix socket flags with one URL-based --host
  flag.
  - Default: http://localhost:8081 northbound API.
  - Supports http://, https://, and unix:///path/to/socket.
  - All commands now target explicitly selected endpoint.
- Change health to check one configured endpoint instead of four default northbound/southbound
  HTTP/TLS endpoints.
- Update job update-status: remove --actor; select client vs management API through --host.
- Update wfx-loadtest client/mgmt config to use full server URLs.
- Report clear error for HTTP failures with empty response body.
- Update docs, demos, BATS tests, and command tests for new host configuration.
- Removed flags include --client-*, --mgmt-*, and --enable-tls.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [X] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
