### PR TITLE
fix(ui): add logo.svg to standalone ui

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -185,6 +185,8 @@ archives:
         dst: app.css
       - src: ui/index.html.tmpl
         dst: index.html.tmpl
+      - src: hugo/static/images/logo.svg
+        dst: logo.svg
       - src: ui/*.cyclonedx.sbom.json
         dst: .
 


### PR DESCRIPTION
### Description

The wfx binary with ui support has the logo.svg built-in, but for the standalone UI, we have to provide the logo.svg.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
