### PR TITLE
ci: split build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,37 @@ jobs:
       - run: sudo .ci/setup-build.sh
       - name: Build Snapshot Release for Linux
         run: /usr/bin/env CC=$(pwd)/.ci/zcc goreleaser release --clean --snapshot
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - name: Upload Linux AMD64 artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: dist
-          path: dist/**/*
+          name: dist-linux-amd64
+          path: |
+            dist/*amd64*
+            dist/*x86_64*
+            dist/*SHA256SUMS
+            dist/artifacts.json
+            dist/metadata.json
+          retention-days: 5
+      - name: Upload Linux ARM64 artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist-linux-arm64
+          path: |
+            dist/*arm64*
+            dist/*aarch64*
+            dist/*SHA256SUMS
+            dist/artifacts.json
+            dist/metadata.json
+          retention-days: 5
+      - name: Upload UI artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist-ui
+          path: |
+            dist/wfxui-*
+            dist/*SHA256SUMS
+            dist/artifacts.json
+            dist/metadata.json
           retention-days: 5
 
   build-windows:


### PR DESCRIPTION
The single dist.zip is quite large and contains cross-arch artifacts, which are usually not needed. Split into three separate artifacts: amd64, arm64 and standalone UI zip.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
