### PR TITLE
chore(hugo): drop docsy from dependencies

### DIFF
--- a/hugo/package-lock.json
+++ b/hugo/package-lock.json
@@ -24,7 +24,6 @@
         "color-name": "^1.1.4",
         "colorjs.io": "^0.7.1",
         "dependency-graph": "^1.0.0",
-        "docsy": "^0.17.0",
         "electron-to-chromium": "^1.5.402",
         "emoji-regex": "^8.0.0",
         "escalade": "^3.2.0",
@@ -714,22 +713,6 @@
       "optional": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/docsy": {
-      "version": "0.17.0",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#8d38d5f12c3a65c31bfb1ae4f6c4fbb05bad0569",
-      "license": "Apache-2.0",
-      "workspaces": [
-        "docsy.dev",
-        "theme"
-      ],
-      "bin": {
-        "gen-favicons": "theme/scripts/gen-favicons/cli.mjs"
-      },
-      "engines": {
-        "node": ">=24",
-        "npm": ">=11.18.0"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/hugo/package.json
+++ b/hugo/package.json
@@ -19,7 +19,6 @@
     "color-name": "^1.1.4",
     "colorjs.io": "^0.7.1",
     "dependency-graph": "^1.0.0",
-    "docsy": "^0.17.0",
     "electron-to-chromium": "^1.5.402",
     "emoji-regex": "^8.0.0",
     "escalade": "^3.2.0",


### PR DESCRIPTION
docsy does not exist on npmjs.
We already have docsy/theme in package.json which is enough.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
