### PR TITLE
build(wfx): exclude ui tag from non-ui build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,8 @@ builds:
   - id: wfx
     binary: wfx
     main: ./cmd/wfx
+    tags:
+      - '!ui' # ensure we build without ui support (overriding GOFLAGS= variable which might be set locally)
     flags:
       - -trimpath
       - -mod=readonly


### PR DESCRIPTION
devenv exports GOFLAGS containing 'ui' when the frontend profile is active, causing goreleaser to unintentionally include UI assets. This only affects local builds.

### Description

Please provide a concise summary of the changes and their motivation.

#### Issues Addressed

List and link all the issues addressed by this PR.

#### Change Type

Please select the relevant options:

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/siemens/wfx/blob/main/CONTRIBUTING.md) document.
- [ ] My changes adhere to the established code style, patterns, and best practices.
- [ ] I have added tests that demonstrate the effectiveness of my changes.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry in the [CHANGELOG](https://github.com/siemens/wfx/blob/main/CHANGELOG.md) to document my changes (if applicable).
